### PR TITLE
Implement BufferCommand.IsBufferIdle

### DIFF
--- a/Command/BufferCommand.cs
+++ b/Command/BufferCommand.cs
@@ -182,8 +182,8 @@ namespace Anvil.CSharp.Command
             }
             else
             {
-                OnBufferIdle?.Invoke(this);
                 IsBufferIdle = true;
+                OnBufferIdle?.Invoke(this);
             }
         }
     }


### PR DESCRIPTION
### PR
Implement `BufferCommand.IsBufferIdle`. This is required in situations where, for whatever reason, you weren't able to catch the `OnBufferIdle` event. It can also be useful if you want to check whether a buffer is still idle after an amount of time passes.
 - Also Fix minor typo in docs

### Notify

@scratch-games/anvil-pr-notifiers
