### PR TITLE
Removing GC Alloc on Acquire

### DIFF
--- a/Pooling/Pool.cs
+++ b/Pooling/Pool.cs
@@ -100,10 +100,11 @@ namespace Anvil.CSharp.Pooling
             T acquiredInstance = null;
             foreach (T instance in m_InstanceSet)
             {
-                m_InstanceSet.Remove(instance);
                 acquiredInstance = instance;
                 break;
             }
+
+            m_InstanceSet.Remove(acquiredInstance);
 
             return acquiredInstance;
         }


### PR DESCRIPTION
### PR

When the Pool Acquire's it used LINQ's `First()` which allocates a bit of garbage. 

This fix removes that by doing what LINQ does anyway internally, albeit it looks more gross but without the allocation.

### Notify

@scratch-games/anvil-pr-notifiers
@tjvezina FYI as well.
