### PR TITLE
Bugfix - Fixing a JSON decode issue

### DIFF
--- a/Data/Serialization/TinyJSON/TinyJSONParser.cs
+++ b/Data/Serialization/TinyJSON/TinyJSONParser.cs
@@ -393,7 +393,7 @@ namespace TinyJSON
                     shouldDecode = false;
                 }
 
-                if (includeAttrType.IsInstanceOfType( attribute ))
+                if (includeAttrType.IsInstanceOfType( attribute ) || decodeAliasAttrType.IsInstanceOfType(attribute))
                 {
                     shouldDecode = true;
                 }


### PR DESCRIPTION
### PR

Fixes an issue where if you have a private variable that you want to decode with a `DecodeAlias` attribute, it won't be decoded unless you also have an `Include` attribute.

Ex.

```
//This will NOT decode
[DecodeAlias("data")] 
private readonly float m_Data;
```

```
//This WILL decode
[DecodeAlias("data"), Include] 
private readonly float m_Data;
```

There's no reason to have a `DecodeAlias` unless the field should be included so this fix just makes it work as you would expect.


### Notify

@scratch-games/anvil-pr-notifiers
