### PR TITLE
Pool - Add overload to release collection of instances

### DIFF
--- a/Pooling/Pool.cs
+++ b/Pooling/Pool.cs
@@ -116,6 +116,20 @@ namespace Anvil.CSharp.Pooling
         /// <exception cref="Exception">Thrown if the instance given is already in the pool.</exception>
         public void Release(T instance) => AddInstance(instance);
 
+        /// <summary>
+        /// Returns a collection of <see cref="T"/> instances to the pool.
+        /// </summary>
+        /// <param name="instances">A collection of instances of <see cref="T"/> to return to the pool.</param>
+        /// <exception cref="Exception">Thrown if the instance given is null.</exception>
+        /// <exception cref="Exception">Thrown if the instance given is already in the pool.</exception>
+        public void Release(IEnumerable<T> instances)
+        {
+            foreach(T instance in instances)
+            {
+                Release(instance);
+            }
+        }
+
         private T CreateInstance()
         {
             m_InstanceCount++;


### PR DESCRIPTION
### PR
It's common to want to release many instances at once. For example, during teardown or disposal operations. This overload allows the developer to cleanly release a collection of instances.


### Notify

@scratch-games/anvil-pr-notifiers
