### PR TITLE
Add Assertion helper debug class

### DIFF
--- a/Debugging/AssertUtil.cs
+++ b/Debugging/AssertUtil.cs
@@ -7,7 +7,7 @@ namespace Anvil.CSharp.Debugging
     /// A collection of convenient checks to make it easier/clearner for developers to assert
     /// complex conditions.
     /// </summary>
-    public static class Assertion
+    public static class AssertUtil
     {
         /// <summary>
         /// Returns true if the executing method is being called by a method with the provided name.


### PR DESCRIPTION
### PR
The beginning of a set of utilities to make more advanced assertions easy to read, clean, one liners.

`Assertion.IsCaller` allows a developer to enforce that a method is being called by a specific method name. The assertion is marked with the `DEBUG` conditional because there's no guarantee that a method name will remain intact in release builds.

#### Example Usage
``` csharp
private void MyCallingMethod()
{
   MyCalledMethod();
}

private void MyCalledMethod()
{
   Assertion.IsCaller(nameof(MyCallingMethod), $"{nameof(MyCalledMethod)} should only ever be called by {nameof(MyCallingMethod)}");
}
```

### Notify

@scratch-games/anvil-pr-notifiers
