### PR TITLE
Allow non-public AbstractUpdateSource implementations constructors

### DIFF
--- a/DelayedExecution/UpdateHandleSourcesManager.cs
+++ b/DelayedExecution/UpdateHandleSourcesManager.cs
@@ -20,7 +20,7 @@ namespace Anvil.CSharp.DelayedExecution
         {
             if (!s_UpdateSources.ContainsKey(sourceType))
             {
-                AbstractUpdateSource updateSource = (AbstractUpdateSource)Activator.CreateInstance(sourceType);
+                AbstractUpdateSource updateSource = (AbstractUpdateSource)Activator.CreateInstance(sourceType, true);
                 s_UpdateSources[sourceType] = updateSource;
             }
 


### PR DESCRIPTION
### PR
Update sources generally shouldn't need to have public constructors. This change allows the constructors of update sources to be non-public.


### Notify

@scratch-games/anvil-pr-notifiers
