### PR TITLE
Allow developer to clear all log handlers

### DIFF
--- a/Logging/.CSProject/Log.cs
+++ b/Logging/.CSProject/Log.cs
@@ -15,8 +15,6 @@ namespace Anvil.CSharp.Logging
             "System", "mscorlib", "Unity", "UnityEngine", "UnityEditor", "nunit"
         };
 
-        private static readonly ILogHandler DEFAULT_HANDLER;
-
         private static readonly HashSet<ILogHandler> s_AdditionalHandlerList = new HashSet<ILogHandler>();
 
         static Log()
@@ -38,7 +36,7 @@ namespace Anvil.CSharp.Logging
                 throw new Exception($"Default log handler {defaultLogHandlerType} does not implement {nameof(ILogHandler)}");
             }
 
-            DEFAULT_HANDLER = (ILogHandler)Activator.CreateInstance(defaultLogHandlerType);
+            AddHandler((ILogHandler)Activator.CreateInstance(defaultLogHandlerType));
 
             bool ShouldIgnore(Assembly assembly)
             {
@@ -66,6 +64,11 @@ namespace Anvil.CSharp.Logging
         /// <param name="handler">The log handler to remove.</param>
         /// <returns>Returns whether the handler was successfully removed.</returns>
         public static bool RemoveHandler(ILogHandler handler) => s_AdditionalHandlerList.Remove(handler);
+
+        /// <summary>
+        /// Removes all log handlers including any default handlers.
+        /// </summary>
+        public static void RemoveAllHandlers() => s_AdditionalHandlerList.Clear();
 
         /// <summary>
         /// Logs a message.
@@ -108,8 +111,6 @@ namespace Anvil.CSharp.Logging
 
         private static void DispatchLog(LogLevel level, string message)
         {
-            DEFAULT_HANDLER.HandleLog(level, message);
-
             foreach (ILogHandler handler in s_AdditionalHandlerList)
             {
                 handler.HandleLog(level, message);


### PR DESCRIPTION
### PR
Add method to allow the removal of all log handlers from the `Log` class. This includes the default handler.

Developing a console application with [gui.cs](https://github.com/migueldeicaza/gui.cs) the default `ConsoleLogHandler` interferes with rendering of the TUI on some platforms.

In my specific case I want my main logging to occur through the `FileLogHandler` in a user defined file. Since the end location is defined at runtime I wasn't able to use `[DefaultLogHandler(priority)]` to override the default. I could have written a handler that allowed me to enable/disable output to the console at runtime but it didn't seem like a very clean solution. Especially considering this will come up a lot as most console applications wouldn't want logging to interfere with the output to their main interface.

As part of the change I've incorporated the default handler into the `s_AdditionalHandlerList` so it's no longer a special guarded handler instance.

### Notify

@scratch-games/anvil-pr-notifiers
