### PR TITLE
TinyJSON - support instantiating types with non-public constructors

### DIFF
--- a/Data/Serialization/TinyJSON/TinyJSONParser.cs
+++ b/Data/Serialization/TinyJSON/TinyJSONParser.cs
@@ -296,7 +296,7 @@ namespace TinyJSON
 
                 if (type.IsAssignableFrom( makeType ))
                 {
-                    instance = (T) Activator.CreateInstance( makeType );
+                    instance = (T) Activator.CreateInstance( makeType, nonPublic: true );
                     type = makeType;
                 }
                 else
@@ -307,7 +307,7 @@ namespace TinyJSON
             else
             {
                 // We don't have a type hint, so just instantiate the type we have.
-                instance = Activator.CreateInstance<T>();
+                instance = (T) Activator.CreateInstance(typeof(T), nonPublic: true);
             }
 
             instanceType = type;


### PR DESCRIPTION
### PR
During deserialziation the JSON parser will now consider non-public constructors.
This allows for data models that can only be created through deserialization.


### Notify

@scratch-games/anvil-pr-notifiers
