### PR TITLE
AbstractTimerUpdateSource - Supply instance ref to onThreadMarshal

### DIFF
--- a/DelayedExecution/UpdateSources/AbstractTimerUpdateSource.cs
+++ b/DelayedExecution/UpdateSources/AbstractTimerUpdateSource.cs
@@ -23,9 +23,9 @@ namespace Anvil.CSharp.DelayedExecution
             InitTimer(updateInterval, (state) => DispatchOnUpdateEvent());
         }
 
-        protected AbstractTimerUpdateSource(float updateInterval, Action<Action> onThreadMarshall)
+        protected AbstractTimerUpdateSource(float updateInterval, Action<AbstractTimerUpdateSource, Action> onThreadMarshall)
         {
-            InitTimer(updateInterval, (state) => onThreadMarshall(DispatchOnUpdateEvent));
+            InitTimer(updateInterval, (state) => onThreadMarshall(this, DispatchOnUpdateEvent));
         }
 
         private void InitTimer(float updateInterval, TimerCallback callback)


### PR DESCRIPTION
### PR
This change allows static thread marshals to manipulate the instance it is marshalling from if needed.
This feature was required for an UpdateSource implementation that had to prevent update pumps while an existing one was being processed.

@jkeon see `ApplicationUpdateSource` for our GUI.cs work.

### Notify

@scratch-games/anvil-pr-notifiers
