### PR TITLE
UpdateHandle - Add IsSourceUpdating

### DIFF
--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -33,7 +33,7 @@ namespace Anvil.CSharp.DelayedExecution
         /// </summary>
         /// <typeparam name="T">The type of <see cref="AbstractUpdateSource"/> to use.</typeparam>
         /// <returns>The instance of the Update Handle</returns>
-        public static UpdateHandle Create<T>() where T:AbstractUpdateSource
+        public static UpdateHandle Create<T>() where T : AbstractUpdateSource
         {
             UpdateHandle updateHandle = new UpdateHandle(typeof(T));
             return updateHandle;
@@ -79,6 +79,14 @@ namespace Anvil.CSharp.DelayedExecution
                 m_OnUpdate -= value;
                 ValidateUpdateSourceHook();
             }
+        }
+
+        /// <summary>
+        /// Indicates whether the handle is currently executing its OnUpdate phase.
+        /// </summary>
+        public bool IsSourceUpdating
+        {
+            get => m_UpdateSource != null && m_UpdateSource.IsUpdating;
         }
 
         private UpdateHandle(Type updateSourceType)

--- a/DelayedExecution/UpdateSources/AbstractUpdateSource.cs
+++ b/DelayedExecution/UpdateSources/AbstractUpdateSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Anvil.CSharp.Core;
 
 namespace Anvil.CSharp.DelayedExecution
@@ -13,6 +14,11 @@ namespace Anvil.CSharp.DelayedExecution
         /// </summary>
         public event Action OnUpdate;
 
+        /// <summary>
+        /// Indicates whether the source is currently executing its OnUpdate phase.
+        /// </summary>
+        public bool IsUpdating { get; private set; }
+
         protected AbstractUpdateSource()
         {
         }
@@ -21,12 +27,19 @@ namespace Anvil.CSharp.DelayedExecution
         {
             UpdateHandleSourcesManager.RemoveUpdateSource(this);
             OnUpdate = null;
+
             base.DisposeSelf();
         }
 
         protected void DispatchOnUpdateEvent()
         {
+            Debug.Assert(!IsUpdating);
+            IsUpdating = true;
+
             OnUpdate?.Invoke();
+
+            Debug.Assert(IsUpdating);
+            IsUpdating = false;
         }
     }
 }


### PR DESCRIPTION
Add boolean flags to the update sources and `UpdateHandle` to indicate when they are within their update phase. This allows executing code to take shortcuts if it knows it's currently executing during an appropriate time in the frame.

**Example:** A system needs to conduct work during `LateUpdate` but doesn't know if it's executing during that phase (or during the `UpdateHandle`'s update call stack) it can check this flag to execute its work immediately instead of scheduling to wait for the next `LateUpdate`.

### What is the current behaviour?
The feature does not exist

### What is the new behaviour?
`UpdateHandle.IsSourceUpdating` is exposed for consumers.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
