### PR TITLE
Extension Methods - Remove namespaces add docs

### DIFF
--- a/Collections/ListExtension.cs
+++ b/Collections/ListExtension.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 
+/// <summary>
+/// Extension methods for use with an <see cref="IList{T}"/> instance.
+/// </summary>
 public static class ListExtension
 {
     /// <summary>

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -1,34 +1,34 @@
-﻿namespace System.Reflection
+﻿
+using System;
+
+/// <summary>
+/// A set of convenience extensions for <see cref="Type"/>
+/// </summary>
+public static class TypeExtension
 {
     /// <summary>
-    /// A set of convenience extensions for <see cref="Type"/>
+    /// Resolves the default value of a provided runtime type.
+    /// The runtime equivalent of `default(MyType)`
     /// </summary>
-    public static class TypeExtension
+    /// <param name="type">The type to resolve the default value for</param>
+    /// <returns>The default value for the given type</returns>
+    /// <remarks>Stolen from: https://stackoverflow.com/a/2490274 </remarks>
+    public static object CreateDefaultValue(this Type type)
     {
-        /// <summary>
-        /// Resolves the default value of a provided runtime type.
-        /// The runtime equivalent of `default(MyType)`
-        /// </summary>
-        /// <param name="type">The type to resolve the default value for</param>
-        /// <returns>The default value for the given type</returns>
-        /// <remarks>Stolen from: https://stackoverflow.com/a/2490274 </remarks>
-        public static object CreateDefaultValue(this Type type)
-        {
-            return type.IsValueType ? Activator.CreateInstance(type) : null;
-        }
+        return type.IsValueType ? Activator.CreateInstance(type) : null;
+    }
 
-        /// <summary>
-        /// Determine whether a type represents a static class.
-        /// </summary>
-        /// <param name="type">The type to check if it's static</param>
-        /// <returns>True if the class is static</returns>
-        /// <remarks>
-        /// This works because a static class is defined as abstract, sealed at the IL level
-        /// Source: https://stackoverflow.com/a/1175901/640196
-        /// </remarks>
-        public static bool isStatic(this Type type)
-        {
-            return type.IsAbstract && type.IsSealed;
-        }
+    /// <summary>
+    /// Determine whether a type represents a static class.
+    /// </summary>
+    /// <param name="type">The type to check if it's static</param>
+    /// <returns>True if the class is static</returns>
+    /// <remarks>
+    /// This works because a static class is defined as abstract, sealed at the IL level
+    /// Source: https://stackoverflow.com/a/1175901/640196
+    /// </remarks>
+    public static bool isStatic(this Type type)
+    {
+        return type.IsAbstract && type.IsSealed;
     }
 }


### PR DESCRIPTION
Remove name spaces from Extension classes and add top level documentation where missing.
Extension classes shouldn't have namespaces so that they are easier for developers to discover (source: #2). Anvil didn't consistently apply this rule until now.

### What is the current behaviour?
Some extension method classes have namespaces that require the developer to import before using.

### What is the new behaviour?
All extension method classes exist at the root namespace.

### What issues does this resolve?
Developer discover ability of namespaces

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No - You may have unused import statements code now.
