### PR TITLE
Log.Logger - Expose fields as public

### DIFF
--- a/Logging/.CSProject/Log.cs
+++ b/Logging/.CSProject/Log.cs
@@ -23,8 +23,14 @@ namespace Anvil.CSharp.Logging
         /// </summary>
         public readonly struct Logger
         {
-            private readonly string m_DerivedTypeName;
-            private readonly string m_MessagePrefix;
+            /// <summary>
+            /// The name of the type this <see cref="Logger"/> represents.
+            /// </summary>
+            public readonly string DerivedTypeName;
+            /// <summary>
+            /// The custom prefix to prepend to all messages sent through this <see cref="Logger"/>.
+            /// </summary>
+            public readonly string MessagePrefix;
 
             /// <summary>
             /// Creates an instance of <see cref="Logger"/> from a <see cref="Type"/>.
@@ -47,8 +53,8 @@ namespace Anvil.CSharp.Logging
 
             private Logger(string derivedTypeName, string messagePrefix)
             {
-                m_DerivedTypeName = derivedTypeName;
-                m_MessagePrefix = messagePrefix;
+                DerivedTypeName = derivedTypeName;
+                MessagePrefix = messagePrefix;
             }
 
             /// <summary>
@@ -64,8 +70,8 @@ namespace Anvil.CSharp.Logging
                 [CallerLineNumber] int callerLine = 0
                 ) => DispatchLog(
                     LogLevel.Debug,
-                    string.Concat(m_MessagePrefix, message),
-                    m_DerivedTypeName,
+                    string.Concat(MessagePrefix, message),
+                    DerivedTypeName,
                     callerPath,
                     callerName,
                     callerLine);
@@ -83,8 +89,8 @@ namespace Anvil.CSharp.Logging
                 [CallerLineNumber] int callerLine = 0
                 ) => DispatchLog(
                     LogLevel.Warning,
-                    string.Concat(m_MessagePrefix, message),
-                    m_DerivedTypeName,
+                    string.Concat(MessagePrefix, message),
+                    DerivedTypeName,
                     callerPath,
                     callerName,
                     callerLine
@@ -103,8 +109,8 @@ namespace Anvil.CSharp.Logging
                 [CallerLineNumber] int callerLine = 0
                 ) => DispatchLog(
                     LogLevel.Error,
-                    string.Concat(m_MessagePrefix, message),
-                    m_DerivedTypeName,
+                    string.Concat(MessagePrefix, message),
+                    DerivedTypeName,
                     callerPath,
                     callerName,
                     callerLine
@@ -125,8 +131,8 @@ namespace Anvil.CSharp.Logging
                 [CallerLineNumber] int callerLine = 0
                 ) => DispatchLog(
                     level,
-                    string.Concat(m_MessagePrefix, message),
-                    m_DerivedTypeName,
+                    string.Concat(MessagePrefix, message),
+                    DerivedTypeName,
                     callerPath,
                     callerName,
                     callerLine);
@@ -204,7 +210,7 @@ namespace Anvil.CSharp.Logging
 
             var logger = GetStaticLogger(typeof(Log));
             foreach (Type listener in candidateTypes)
-            {   
+            {
                 Activator.CreateInstance(listener);
                 logger.Debug($"Default Log listener {listener.Name} initialized. Source: {listener.AssemblyQualifiedName}");
             }

--- a/Logging/Anvil.CSharp.Logging.dll
+++ b/Logging/Anvil.CSharp.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:400e67811cea526b5ef8915eb5385ee968bd7b29b5af02064315b41b89498f79
+oid sha256:b2711d199a5ab66fa00ae5c80b81741fd453bb968ec2aedd3e856121f9046bb4
 size 11776


### PR DESCRIPTION
Expose `Log.Logger` readonly fields as public. Required for functionality introduced in https://github.com/decline-cookies/anvil-unity-dots/pull/30

### What is the current behaviour?
Fields are private

### What is the new behaviour?
Fields are public

### What issues does this resolve?
Deriving new logger types for specific platforms/compilers/contexts can't currently match the values of the default `Log.Logger` instances. This change allows those specialized logger types to extract any information they require.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
