### PR TITLE
Add CollectionExtension with DisposeAllAndClear

### DIFF
--- a/Collections/CollectionExtension.cs
+++ b/Collections/CollectionExtension.cs
@@ -9,9 +9,9 @@ namespace Anvil.CSharp.Collections
     public static class CollectionExtension
     {
         /// <summary>
-        /// Dispose all elements of a <see cref="ICollection{T}"/> then clear.
+        /// Dispose all elements of a <see cref="ICollection{T}"/> and then clear the collection.
         /// </summary>
-        /// <param name="collection">A collection of elements to dispose then clear.</param>
+        /// <param name="collection">The <see cref="ICollection{T}"/> to operate on.</param>
         /// <typeparam name="T">The element type</typeparam>
         public static void DisposeAllAndClear<T>(this ICollection<T> collection) where T : IDisposable
         {

--- a/Collections/CollectionExtension.cs
+++ b/Collections/CollectionExtension.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anvil.CSharp.Collections
+{
+    /// <summary>
+    /// Extension methods for use with <see cref="ICollection{T}"/> instances.
+    /// </summary>
+    public static class CollectionExtension
+    {
+        /// <summary>
+        /// Dispose all elements of a <see cref="ICollection{T}"/> then clear.
+        /// </summary>
+        /// <param name="collection">A collection of elements to dispose then clear.</param>
+        /// <typeparam name="T">The element type</typeparam>
+        public static void DisposeAllAndClear<T>(this ICollection<T> collection) where T : IDisposable
+        {
+            foreach (T item in collection)
+            {
+                item.Dispose();
+            }
+
+            collection.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Add `CollectionExtension` with `DisposeAllAndClear` method.

### What is the current behaviour?
Developers have to build their own iterations to dispose of a collection of `IDisposable` elements.
THEN they have to clear the collection manually. Can you believe it?!

### What is the new behaviour?
With one easy extension method call developers can now have their collection's elements disposed and then cleared out.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
