### PR TITLE
Implement `OneTimeLogger` + Minor Refactor + `ILogger`

### DIFF
--- a/Core/AbstractAnvilBase.cs
+++ b/Core/AbstractAnvilBase.cs
@@ -19,12 +19,12 @@ namespace Anvil.CSharp.Core
         /// </summary>
         public bool IsDisposing { get; private set; }
 
-        private Log.Logger? m_Logger;
+        private Logger? m_Logger;
         /// <summary>
         /// Returns a <see cref="Log.Logger"/> for this instance to emit log messages with.
         /// Lazy instantiated.
         /// </summary>
-        protected Log.Logger Logger
+        protected Logger Logger
         {
             get => m_Logger ?? (m_Logger = Log.GetLogger(this)).Value;
             set => m_Logger = value;
@@ -54,4 +54,3 @@ namespace Anvil.CSharp.Core
         protected virtual void DisposeSelf() { }
     }
 }
-

--- a/Logging/.CSProject/Anvil.CSharp.Logging.csproj
+++ b/Logging/.CSProject/Anvil.CSharp.Logging.csproj
@@ -40,6 +40,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Log.cs" />
+    <Compile Include="Logger\ILogger.cs" />
+    <Compile Include="Logger\Logger.cs" />
+    <Compile Include="Logger\OneTimeLogger.cs" />
     <Compile Include="LogHandler\ConsoleLogHandler.cs" />
     <Compile Include="LogHandler\ILogHandler.cs" />
     <Compile Include="LogLevel.cs" />

--- a/Logging/.CSProject/Anvil.CSharp.Logging.csproj.DotSettings
+++ b/Logging/.CSProject/Anvil.CSharp.Logging.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=logger/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=loghandler/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=loglistener/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Logging/.CSProject/Log.cs
+++ b/Logging/.CSProject/Log.cs
@@ -22,7 +22,7 @@ namespace Anvil.CSharp.Logging
         /// Returns true while a log is being evaluated by handlers.
         /// Returns false at all other times.
         /// </summary>
-        public static bool SupressLogging { get; set; } = false;
+        public static bool SuppressLogging { get; set; } = false;
 
         /// <summary>
         /// While set to true handling of any incoming log messages is skipped.
@@ -147,7 +147,7 @@ namespace Anvil.CSharp.Logging
             string callerName,
             int callerLine)
         {
-            if (SupressLogging)
+            if (SuppressLogging)
             {
                 return;
             }

--- a/Logging/.CSProject/Log.cs
+++ b/Logging/.CSProject/Log.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Anvil.CSharp.Logging
 {
@@ -12,132 +11,6 @@ namespace Anvil.CSharp.Logging
     /// </summary>
     public static class Log
     {
-        /// <summary>
-        /// A context specific instance that provides a mechanism to emit logs through <see cref="Log"/>.
-        /// Automatically provides contextual information to <see cref="Log"/> about caller context including:
-        ///  - Optional, per instance, message prefix
-        ///  - Caller type name
-        ///  - Caller file path
-        ///  - Caller name
-        ///  - Caller line number
-        /// </summary>
-        public readonly struct Logger
-        {
-            /// <summary>
-            /// The name of the type this <see cref="Logger"/> represents.
-            /// </summary>
-            public readonly string DerivedTypeName;
-            /// <summary>
-            /// The custom prefix to prepend to all messages sent through this <see cref="Logger"/>.
-            /// </summary>
-            public readonly string MessagePrefix;
-
-            /// <summary>
-            /// Creates an instance of <see cref="Logger"/> from a <see cref="Type"/>.
-            /// </summary>
-            /// <param name="type">The <see cref="Type"/> to create the <see cref="Logger"/> instance for.</param>
-            /// <param name="messagePrefix">
-            /// An optional <see cref="string"/> to prefix to all messages through this logger.
-            /// Useful when there are multiple types that share the same name which need to be differentiated.
-            /// </param>
-            public Logger(Type type, string messagePrefix = null) : this(type.Name, messagePrefix) { }
-            /// <summary>
-            /// Creates an instance of <see cref="Logger"/> from an instance.
-            /// </summary>
-            /// <param name="instance">The instance to create the <see cref="Logger"/> instance for.</param>
-            /// <param name="messagePrefix">
-            /// An optional <see cref="string"/> to prefix to all messages through this logger.
-            /// Useful when there are multiple instances or types that share the same name which need to be differentiated.
-            /// </param>
-            public Logger(in object instance, string messagePrefix = null) : this(instance.GetType().Name, messagePrefix) { }
-
-            private Logger(string derivedTypeName, string messagePrefix)
-            {
-                DerivedTypeName = derivedTypeName;
-                MessagePrefix = messagePrefix;
-            }
-
-            /// <summary>
-            /// Logs a message.
-            /// </summary>
-            /// <param name="message">
-            /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
-            /// </param>
-            public void Debug(
-                object message,
-                [CallerFilePath] string callerPath = "",
-                [CallerMemberName] string callerName = "",
-                [CallerLineNumber] int callerLine = 0
-                ) => DispatchLog(
-                    LogLevel.Debug,
-                    string.Concat(MessagePrefix, message),
-                    DerivedTypeName,
-                    callerPath,
-                    callerName,
-                    callerLine);
-
-            /// <summary>
-            /// Logs a warning message.
-            /// </summary>
-            /// <param name="message">
-            /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
-            /// </param>
-            public void Warning(
-                object message,
-                [CallerFilePath] string callerPath = "",
-                [CallerMemberName] string callerName = "",
-                [CallerLineNumber] int callerLine = 0
-                ) => DispatchLog(
-                    LogLevel.Warning,
-                    string.Concat(MessagePrefix, message),
-                    DerivedTypeName,
-                    callerPath,
-                    callerName,
-                    callerLine
-                    );
-
-            /// <summary>
-            /// Logs an error message.
-            /// </summary>
-            /// <param name="message">
-            /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
-            /// </param>
-            public void Error(
-                object message,
-                [CallerFilePath] string callerPath = "",
-                [CallerMemberName] string callerName = "",
-                [CallerLineNumber] int callerLine = 0
-                ) => DispatchLog(
-                    LogLevel.Error,
-                    string.Concat(MessagePrefix, message),
-                    DerivedTypeName,
-                    callerPath,
-                    callerName,
-                    callerLine
-                    );
-
-            /// <summary>
-            /// Logs a message to the level provided.
-            /// </summary>
-            /// <param name="level">The level to log at.</param>
-            /// <param name="message">
-            /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
-            /// </param>
-            public void AtLevel(
-                LogLevel level,
-                object message,
-                [CallerFilePath] string callerPath = "",
-                [CallerMemberName] string callerName = "",
-                [CallerLineNumber] int callerLine = 0
-                ) => DispatchLog(
-                    level,
-                    string.Concat(MessagePrefix, message),
-                    DerivedTypeName,
-                    callerPath,
-                    callerName,
-                    callerLine);
-        }
-
         private static readonly string[] IGNORE_ASSEMBLIES =
         {
             "System", "mscorlib", "Unity", "UnityEngine", "UnityEditor", "nunit"
@@ -266,7 +139,7 @@ namespace Anvil.CSharp.Logging
         /// <returns>The configured <see cref="Logger"/> instance</returns>
         public static Logger GetLogger(in object instance, string messagePrefix = null) => new Logger(in instance, messagePrefix);
 
-        private static void DispatchLog(
+        internal static void DispatchLog(
             LogLevel level,
             string message,
             string callerDerivedTypeName,

--- a/Logging/.CSProject/Logger/ILogger.cs
+++ b/Logging/.CSProject/Logger/ILogger.cs
@@ -1,0 +1,66 @@
+using System.Runtime.CompilerServices;
+
+namespace Anvil.CSharp.Logging
+{
+    /// <summary>
+    /// An instance that provides a mechanism to emit logs through <see cref="Log"/>.
+    /// Not intended to be used directly. This is used to keep the APIs of <see cref="Logger"/> and
+    /// <see cref="OneTimeLogger"/> in sync.
+    /// </summary>
+    internal interface ILogger
+    {
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
+        /// <param name="message">
+        /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
+        /// </param>
+        void Debug(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        );
+
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
+        /// <param name="message">
+        /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
+        /// </param>
+        void Warning(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        );
+
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
+        /// <param name="message">
+        /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
+        /// </param>
+        void Error(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        );
+
+        /// <summary>
+        /// Logs a message to the level provided.
+        /// </summary>
+        /// <param name="level">The level to log at.</param>
+        /// <param name="message">
+        /// The message object to log. The object is converted to a <see cref="string"/> by <see cref="object.ToString"/>.
+        /// </param>
+        void AtLevel(
+            LogLevel level,
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        );
+    }
+}

--- a/Logging/.CSProject/Logger/Logger.cs
+++ b/Logging/.CSProject/Logger/Logger.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Anvil.CSharp.Logging
+{
+    /// <summary>
+    /// A context specific instance that provides a mechanism to emit logs through <see cref="Log"/>.
+    /// Automatically provides contextual information to <see cref="Log"/> about caller context including:
+    ///  - Optional, per instance, message prefix
+    ///  - Caller type name
+    ///  - Caller file path
+    ///  - Caller name
+    ///  - Caller line number
+    /// </summary>
+    public readonly struct Logger : ILogger
+    {
+        /// <summary>
+        /// The name of the type this <see cref="Logger"/> represents.
+        /// </summary>
+        public readonly string DerivedTypeName;
+        /// <summary>
+        /// The custom prefix to prepend to all messages sent through this <see cref="Logger"/>.
+        /// </summary>
+        public readonly string MessagePrefix;
+
+        /// <summary>
+        /// Creates an instance of <see cref="Logger"/> from a <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to create the <see cref="Logger"/> instance for.</param>
+        /// <param name="messagePrefix">
+        /// An optional <see cref="string"/> to prefix to all messages through this logger.
+        /// Useful when there are multiple types that share the same name which need to be differentiated.
+        /// </param>
+        public Logger(Type type, string messagePrefix = null) : this(type.Name, messagePrefix) { }
+        /// <summary>
+        /// Creates an instance of <see cref="Logger"/> from another instance.
+        /// </summary>
+        /// <param name="instance">The instance to create the <see cref="Logger"/> instance for.</param>
+        /// <param name="messagePrefix">
+        /// An optional <see cref="string"/> to prefix to all messages through this logger.
+        /// Useful when there are multiple instances or types that share the same name which need to be differentiated.
+        /// </param>
+        public Logger(in object instance, string messagePrefix = null) : this(instance.GetType().Name, messagePrefix) { }
+
+        private Logger(string derivedTypeName, string messagePrefix)
+        {
+            DerivedTypeName = derivedTypeName;
+            MessagePrefix = messagePrefix;
+        }
+
+        /// <inheritdoc cref="ILogger.Debug"/>
+        public void Debug(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        ) => Log.DispatchLog(
+            LogLevel.Debug,
+            string.Concat(MessagePrefix, message),
+            DerivedTypeName,
+            callerPath,
+            callerName,
+            callerLine);
+
+        /// <inheritdoc cref="ILogger.Warning"/>
+        public void Warning(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        ) => Log.DispatchLog(
+            LogLevel.Warning,
+            string.Concat(MessagePrefix, message),
+            DerivedTypeName,
+            callerPath,
+            callerName,
+            callerLine
+        );
+
+        /// <inheritdoc cref="ILogger.Error"/>
+        public void Error(
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        ) => Log.DispatchLog(
+            LogLevel.Error,
+            string.Concat(MessagePrefix, message),
+            DerivedTypeName,
+            callerPath,
+            callerName,
+            callerLine
+        );
+
+        /// <inheritdoc cref="ILogger.AtLevel"/>
+        public void AtLevel(
+            LogLevel level,
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0
+        ) => Log.DispatchLog(
+            level,
+            string.Concat(MessagePrefix, message),
+            DerivedTypeName,
+            callerPath,
+            callerName,
+            callerLine);
+
+        public OneTimeLogger OneTime() => new OneTimeLogger(this);
+    }
+}

--- a/Logging/.CSProject/Logger/OneTimeLogger.cs
+++ b/Logging/.CSProject/Logger/OneTimeLogger.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Anvil.CSharp.Logging
+{
+    /// <summary>
+    /// A wrapper for <see cref="Logger"/> that only allows a message to be emitted from a given call site once per session.
+    /// A call site is determined to be unique by a combination of its file path and line number.
+    /// </summary>
+    public readonly struct OneTimeLogger : ILogger
+    {
+        private static readonly HashSet<int> s_CalledLogSites = new HashSet<int>();
+
+        /// <summary>
+        /// Resets <see cref="OneTimeLogger"/>'s to allow one time logs to be emitted one more time.
+        /// </summary>
+        public static void Reset()
+        {
+            s_CalledLogSites.Clear();
+        }
+
+
+        private readonly Logger m_Logger;
+
+
+        internal OneTimeLogger(in Logger logger)
+        {
+            m_Logger = logger;
+        }
+
+        /// <inheritdoc cref="ILogger.Debug"/>
+        public void Debug(object message, [CallerFilePath] string callerPath = "", [CallerMemberName] string callerName = "", [CallerLineNumber] int callerLine = 0)
+        {
+            if (!ShouldEmitLog(callerPath, callerLine))
+            {
+                return;
+            }
+
+            m_Logger.Debug(message, callerPath, callerName, callerLine);
+        }
+
+        /// <inheritdoc cref="ILogger.Warning"/>
+        public void Warning(object message, [CallerFilePath] string callerPath = "", [CallerMemberName] string callerName = "", [CallerLineNumber] int callerLine = 0)
+        {
+            if (!ShouldEmitLog(callerPath, callerLine))
+            {
+                return;
+            }
+
+            m_Logger.Warning(message, callerPath, callerName, callerLine);
+        }
+
+        /// <inheritdoc cref="ILogger.Error"/>
+        public void Error(object message, [CallerFilePath] string callerPath = "", [CallerMemberName] string callerName = "", [CallerLineNumber] int callerLine = 0)
+        {
+            if (!ShouldEmitLog(callerPath, callerLine))
+            {
+                return;
+            }
+
+            m_Logger.Error(message, callerPath, callerName, callerLine);
+        }
+
+        /// <inheritdoc cref="ILogger.AtLevel"/>
+        public void AtLevel(
+            LogLevel level,
+            object message,
+            [CallerFilePath] string callerPath = "",
+            [CallerMemberName] string callerName = "",
+            [CallerLineNumber] int callerLine = 0)
+        {
+            if (!ShouldEmitLog(callerPath, callerLine))
+            {
+                return;
+            }
+
+            m_Logger.AtLevel(level, message, callerPath, callerName, callerLine);
+        }
+
+        private bool ShouldEmitLog(string callerPath, int callerLine)
+        {
+            int hash = (callerPath, callerLine).GetHashCode();
+            return s_CalledLogSites.Add(hash);
+        }
+    }
+}

--- a/Logging/Anvil.CSharp.Logging.dll
+++ b/Logging/Anvil.CSharp.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2711d199a5ab66fa00ae5c80b81741fd453bb968ec2aedd3e856121f9046bb4
-size 11776
+oid sha256:fb1071120d0cfd2d52dc850004e303189ac24e9ad4aaa72b42d7344ca213754f
+size 12800


### PR DESCRIPTION
Implements the ability to configure a log message to only ever emit one time, per session, from a given call site. This allows developers to log information from a location that gets executed frequently (frame updates) without spamming the console.

Move `Log.Logger` out into its own type rather than remaining nested under the `Log` type. Also fixed some spelling mistakes.

Create ILogger to help keep all Logger implementation APIs in sync

**Tag Along**
 - Configured directories in the Logger project to exclude sub-directories from namespace contribution. This allows Rider to suggest the correct namespaces for types.

### What is the current behaviour?
 - There is no way to one time log
 - The `Logger` type is declared within the `Log` type.
 - Various `Logger` implementation APIs are kept in sync manually.

### What is the new behaviour?
#### One Time Logging
The developer can now declare a one time log by: `myLogger.OneTime().Warning("This log will only be emitted once per session");`
The `OneTimeLogger` generates a hash for each call site based on the caller path and line number. This hash is stored in a hash set on first call and used to check whether the call has been issued before.

`OneTimeLogger.Reset()` can be called to reset the log tracking and allow all one time messages to be emitted once more.

#### Move `Logger` out of `Log`
Moved out since there are now multiple implementations of `Logger` it didn't make sense to keep `Logger` as an inner type of `Log`.

Re Spelling: "Suppress" was incorrectly spelled throughout the types 🤦 

#### ILogger
All (sort of) Logger implementations now implement the `ILogger` interface. This will help us keep the Logger APIs in sync.
 - The one Logger that can't implement `ILogger` is [BurstableLogger](https://github.com/decline-cookies/anvil-unity-dots/blob/main/Scripts/Runtime/Logging/BurstableLogger.cs). This is fine, BurstableLogger is a very restricted logger that barely works. As the Burst compiler gains features there's a good chance we'll be able to bring that logger inline with `ILogger`.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes
 - [ ] No

- All references to `Log.Logger` must be changed to `Logger`.
- Any use of `Log.SupressLogging` must be changed to `Log.SuppressLogging`