### PR TITLE
BufferCommand - Add exclude current child on clear option

### DIFF
--- a/Command/BufferCommand.cs
+++ b/Command/BufferCommand.cs
@@ -134,14 +134,30 @@ namespace Anvil.CSharp.Command
         /// Clears all commands in the <see cref="BufferCommand"/> and disposes them.
         /// Will not dispatch <see cref="OnBufferIdle"/>.
         /// </summary>
-        public void Clear()
+        /// <param name="excludeCurrentChild">
+        /// If true, the currently executing child will not be cleared/disposed and it will continue to execute.
+        /// </param>
+        public void Clear(bool excludeCurrentChild = false)
         {
+            if (excludeCurrentChild && m_CurrentChild != null)
+            {
+                m_ChildCommands.Dequeue();
+            }
+
             foreach (T childCommand in m_ChildCommands)
             {
                 childCommand.Dispose();
             }
-
             m_ChildCommands.Clear();
+
+            if (excludeCurrentChild && m_CurrentChild != null)
+            {
+                m_ChildCommands.Enqueue(m_CurrentChild);
+            }
+            else
+            {
+                m_CurrentChild = null;
+            }
         }
 
         protected override void ExecuteCommand()


### PR DESCRIPTION
Add option to exclude the currently executing command in a `BufferCommand` from being cleared when calling `Clear()`.

### What is the current behaviour?
When `BufferCommand.Clear()` is called the currently executing command is cleared/disposed along with any other queued commands.

### What is the new behaviour?
An optional boolean flag may be provided to (`true`) may be provided to prevent the currently executing command from being disposed/cleared.

This is useful when commands in the buffer have graceful exit logic and you want to allow the current command to gracefully shut down while changing out all of the pending commands. This is a typical desire with goal oriented game AI.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
