### PR TITLE
Add DictionaryExtension - Dispose Values Convenience

### DIFF
--- a/Collections/DictionaryExtension.cs
+++ b/Collections/DictionaryExtension.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Anvil.CSharp.Collections
+{
+    public static class DictionaryExtension
+    {
+        /// <summary>
+        /// Dispose all elements of a <see cref="Dictionary{TKey,TValue}"/> and then clear the dictionary.
+        /// </summary>
+        /// <param name="dictionary">The <see cref="Dictionary{TKey,TValue}"/> to operate on.</param>
+        /// <typeparam name="TKey">The key type</typeparam>
+        /// <typeparam name="TValue">The value type</typeparam>
+        public static void DisposeAllValuesAndClear<TKey, TValue>(this Dictionary<TKey, TValue> dictionary) where TValue : IDisposable
+        {
+            foreach (TValue value in dictionary.Values)
+            {
+                value.Dispose();
+            }
+
+            dictionary.Clear();
+        }
+    }
+}


### PR DESCRIPTION
Add `DictionaryExtension.DisposeAllValuesAndClear`.

### What is the current behaviour?
 - None

### What is the new behaviour?
`DictionaryExtension.DisposeAllValuesAndClear` will dispose all values in a `Dictionary` and then clear the `Dictionary`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
