### PR TITLE
CollectionExtension - Fix error on DisposeAndClear

### DIFF
--- a/Collections/CollectionExtension.cs
+++ b/Collections/CollectionExtension.cs
@@ -13,14 +13,17 @@ namespace Anvil.CSharp.Collections
         /// </summary>
         /// <param name="collection">The <see cref="ICollection{T}"/> to operate on.</param>
         /// <typeparam name="T">The element type</typeparam>
-        public static void DisposeAllAndClear<T>(this ICollection<T> collection) where T : IDisposable
+        public static void DisposeAllAndTryClear<T>(this ICollection<T> collection) where T : IDisposable
         {
             foreach (T item in collection)
             {
                 item.Dispose();
             }
 
-            collection.Clear();
+            if (!collection.IsReadOnly)
+            {
+                collection.Clear();
+            }
         }
     }
 }

--- a/Collections/CollectionExtension.cs
+++ b/Collections/CollectionExtension.cs
@@ -13,6 +13,9 @@ namespace Anvil.CSharp.Collections
         /// </summary>
         /// <param name="collection">The <see cref="ICollection{T}"/> to operate on.</param>
         /// <typeparam name="T">The element type</typeparam>
+        /// <remarks>
+        /// This method will only clear the <see cref="collection"/> if <see cref="ICollection{T}.IsReadOnly"/> is false.
+        /// </remarks>
         public static void DisposeAllAndTryClear<T>(this ICollection<T> collection) where T : IDisposable
         {
             foreach (T item in collection)


### PR DESCRIPTION
Fix bug where `CollectionExtension.DisposeAndClear` would throw an exception on collections that cannot be cleared (ex: `Array`)

### What is the current behaviour?
Non-clearable collections (Ex: Array) throw an error.

### What is the new behaviour?
 - Add a guard against clearing collections where `ICollection<T>.IsReadOnly` is true. 
 - Rename method to reflect change in behaviour.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - Any uses of `CollectionExtension.DisposeAllAndClear` must be renamed to `DisposeAllAndTryClear`
 - [ ] No
