### PR TITLE
Changed Logging library .NET Framework version from 4.8 to 4.7.1

### DIFF
--- a/Core/AbstractAnvilBase.cs
+++ b/Core/AbstractAnvilBase.cs
@@ -21,7 +21,7 @@ namespace Anvil.CSharp.Core
 
         private Logger? m_Logger;
         /// <summary>
-        /// Returns a <see cref="Log.Logger"/> for this instance to emit log messages with.
+        /// Returns a <see cref="Logger"/> for this instance to emit log messages with.
         /// Lazy instantiated.
         /// </summary>
         protected Logger Logger

--- a/Logging/.CSProject/Anvil.CSharp.Logging.csproj
+++ b/Logging/.CSProject/Anvil.CSharp.Logging.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Anvil.CSharp.Logging</RootNamespace>
     <AssemblyName>Anvil.CSharp.Logging</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Logging/Anvil.CSharp.Logging.dll
+++ b/Logging/Anvil.CSharp.Logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb1071120d0cfd2d52dc850004e303189ac24e9ad4aaa72b42d7344ca213754f
+oid sha256:5e4c170133b46ce5ff2462639747f4cf73b0bb7eac904c45913a093942e060b7
 size 12800


### PR DESCRIPTION
Corresponding Unity PR: https://github.com/decline-cookies/anvil-unity-core/pull/69

A harmless change the Logging library's .NET version (it does not rely on any Framework 4.8-specific features) to satisfy Omnisharp in VS Code.

It seems Visual Studio and other IDE's are somehow smart enough to still use the Logging DLL despite the minor version mismatch, while Omnisharp just flatly gives up and stops loading the project until you fix it.

(Also corrected a cref from `Log.Logger` -> `Logger`)

### What is the current behaviour?

Anvil.CSharp.Logging.dll targets .NET Framework 4.8, causing VS Code's C# extension to throw errors about using libraries with a newer .NET version than the project itself (Framework 4.7.1).

### What is the new behaviour?

Anvil.CSharp.Logging.dll targets .NET Framework 4.7.1, allowing VS Code to open the project without complaint.

### What issues does this resolve?
Unity projects using Anvil would fail to load in VS Code until you picked some arbitrary fix, like manually editing the .csproj to use 4.8, or giving up and using Visual Studio.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No
