### PR TITLE
Add IDProvider

### DIFF
--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -5,7 +5,7 @@ using Anvil.CSharp.Logging;
 namespace Anvil.CSharp.Data
 {
     /// <summary>
-    /// An instance that provides a unique IDs each time requested.
+    /// An instance that provides a unique ID each time it is requested.
     /// Includes a mechanism to detect when ID supply is near exhaustion.
     /// </summary>
     public class IDProvider

--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -45,7 +45,7 @@ namespace Anvil.CSharp.Data
         /// (default: <see cref="uint.MaxValue"/>) The threshold which, when passed, triggers
         /// <see cref="OnIDLimitImminent"/>.
         /// </param>
-        public IDProvider(uint supplyWarningThreshold = uint.MaxValue-1)
+        public IDProvider(uint supplyWarningThreshold = uint.MaxValue - 1_000_000)
         {
             SupplyWarningThreshold = supplyWarningThreshold;
         }

--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -11,11 +11,49 @@ namespace Anvil.CSharp.Data
     public class IDProvider
     {
         /// <summary>
+        /// Arguments that describe an ID limit warning.
+        /// </summary>
+        public class IDLimitWarningEventArgs : EventArgs
+        {
+            /// <summary>
+            /// Indicates whether the limit warning has been handled. If true, no further corrective action is required
+            /// by the application.
+            /// </summary>
+            public bool IsHandled { get; private set; }
+
+            /// <summary>
+            /// Creates a new instance.
+            /// </summary>
+            internal IDLimitWarningEventArgs()
+            {
+                IsHandled = false;
+            }
+
+            /// <summary>
+            /// Call if the limit has been handled and no corrective action is required by the application.
+            /// The event will continue to be raised to handlers for informational purposes (Logging, analytics, etc..)
+            /// </summary>
+            /// <remarks>
+            /// Calling <see cref="Handle"/> multiple times on a single event will raise a warning. While handling the
+            /// limit multiple times probably isn't harmful, it's not recommended.
+            /// </remarks>
+            public void Handle()
+            {
+                if (IsHandled)
+                {
+                    Log.GetLogger(this).Warning($"ID supply limit has already been handled by another listener and shouldn't get handled again.");
+                }
+
+                IsHandled = true;
+            }
+        }
+
+        /// <summary>
         /// Triggers the first time that any instance of <see cref="IDProvider"/> passes its
         /// <see cref="SupplyWarningThreshold"/> for the first time.
         /// This gives the application the opportunity to react before IDs are exhausted.
         /// </summary>
-        public static event Action<IDProvider> OnIDLimitGlobalWarning;
+        public static event EventHandler<IDLimitWarningEventArgs> OnIDLimitGlobalWarning;
 
         /// <summary>
         /// A reserved ID to represent "No ID".
@@ -27,7 +65,7 @@ namespace Anvil.CSharp.Data
         /// Triggers the first time that <see cref="SupplyWarningThreshold"/> is passed.
         /// This gives the consumer the opportunity to react before IDs are exhausted.
         /// </summary>
-        public event Action OnIDLimitWarning;
+        public event EventHandler<IDLimitWarningEventArgs> OnIDLimitWarning;
 
         /// <summary>
         /// The threshold which, when passed, triggers <seealso cref="OnIDLimitWarning"/>.
@@ -75,13 +113,17 @@ namespace Anvil.CSharp.Data
 
         private void CheckIfIDThresholdCrossed()
         {
-            if (m_LastNewID > SupplyWarningThreshold && m_HasIDWarningTriggered)
+            if (m_LastNewID <= SupplyWarningThreshold || m_HasIDWarningTriggered)
             {
-                Log.GetLogger(this).Warning($"{nameof(IDProvider)} has passed its supply warning threshold. Threshold: {SupplyWarningThreshold}");
-                m_HasIDWarningTriggered = true;
-                OnIDLimitWarning?.Invoke();
-                OnIDLimitGlobalWarning?.Invoke(this);
+                return;
             }
+
+            Log.GetLogger(this).Warning($"{nameof(IDProvider)} has passed its supply warning threshold. Threshold: {SupplyWarningThreshold:N0}");
+            m_HasIDWarningTriggered = true;
+
+            IDLimitWarningEventArgs args = new IDLimitWarningEventArgs();
+            OnIDLimitWarning?.Invoke(this, args);
+            OnIDLimitGlobalWarning?.Invoke(this, args);
         }
     }
 }

--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Diagnostics;
+using Anvil.CSharp.Logging;
+
+namespace Anvil.CSharp.Data
+{
+    /// <summary>
+    /// An instance that provides a unique IDs each time requested.
+    /// Includes a mechanism to detect when ID supply is near exhaustion.
+    /// </summary>
+    public class IDProvider
+    {
+        /// <summary>
+        /// Triggers the first time that any instance of <see cref="IDProvider"/> passes its
+        /// <see cref="SupplyWarningThreshold"/> for the first time.
+        /// This gives the application the opportunity to react before IDs are exhausted.
+        /// </summary>
+        public static event Action<IDProvider> OnIDLimitGlobalWarning;
+
+        /// <summary>
+        /// A reserved ID to represent "No ID".
+        /// <see cref="GetNextID"/> will never return this value even when IDs roll over and are no longer unique.
+        /// </summary>
+        public const int UNSET_ID = 0;
+
+        /// <summary>
+        /// Triggers the first time that <see cref="SupplyWarningThreshold"/> is passed.
+        /// This gives the consumer the opportunity to react before IDs are exhausted.
+        /// </summary>
+        public event Action OnIDLimitWarning;
+
+        public readonly uint SupplyWarningThreshold;
+
+        private bool m_HasIDWarningTriggered = false;
+        private uint m_LastNewID = 0;
+
+
+        /// <summary>
+        /// Creates a new ID provider optionally allowing a supply warning threshold to be set.
+        /// </summary>
+        /// <param name="supplyWarningThreshold">
+        /// (default: <see cref="uint.MaxValue"/>) The threshold which, when passed, triggers
+        /// <see cref="OnIDLimitImminent"/>.
+        /// </param>
+        public IDProvider(uint supplyWarningThreshold = uint.MaxValue-1)
+        {
+            SupplyWarningThreshold = supplyWarningThreshold;
+        }
+
+        /// <summary>
+        /// Provide an unused ID.
+        /// </summary>
+        /// <returns>A unique ID.</returns>
+        /// <remarks>
+        /// If <see cref="uint"/> has rolled over an error will be logged and IDs are no longer guaranteed to be unique.
+        /// </remarks>
+        public uint GetNextID()
+        {
+            uint id = ++m_LastNewID;
+            CheckIfIDThresholdCrossed();
+
+            if (m_LastNewID == 0)
+            {
+                Log.GetLogger(this).Error($"{nameof(IDProvider)} has passed its maximum ID value. IDs provided are no longer guaranteed to be unique.");
+                // Push the ID past the UNSET_ID value so at least THAT remains unique.
+                id = ++m_LastNewID;
+            }
+
+            Debug.Assert(id != UNSET_ID);
+            return id;
+        }
+
+        private void CheckIfIDThresholdCrossed()
+        {
+            if (m_LastNewID > SupplyWarningThreshold && m_HasIDWarningTriggered)
+            {
+                Log.GetLogger(this).Warning($"{nameof(IDProvider)} has passed its supply warning threshold. Threshold: {SupplyWarningThreshold}");
+                m_HasIDWarningTriggered = true;
+                OnIDLimitWarning?.Invoke();
+                OnIDLimitGlobalWarning?.Invoke(this);
+            }
+        }
+    }
+}

--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -29,6 +29,9 @@ namespace Anvil.CSharp.Data
         /// </summary>
         public event Action OnIDLimitWarning;
 
+        /// <summary>
+        /// The threshold which, when passed, triggers <seealso cref="OnIDLimitWarning"/>.
+        /// </summary>
         public readonly uint SupplyWarningThreshold;
 
         private bool m_HasIDWarningTriggered = false;

--- a/Data/IDProvider.cs
+++ b/Data/IDProvider.cs
@@ -21,7 +21,7 @@ namespace Anvil.CSharp.Data
         /// A reserved ID to represent "No ID".
         /// <see cref="GetNextID"/> will never return this value even when IDs roll over and are no longer unique.
         /// </summary>
-        public const int UNSET_ID = 0;
+        public const uint UNSET_ID = 0;
 
         /// <summary>
         /// Triggers the first time that <see cref="SupplyWarningThreshold"/> is passed.

--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -42,7 +42,7 @@ namespace Anvil.CSharp.DelayedExecution
         // Seems likely that an application wouldn't need more than 100 more delayed calls before it can
         // create a new UpdateHandle to work with.
         // If this is an issue there's no risk to having the threshold trigger sooner.
-        private readonly IDProvider m_IDProvider = new IDProvider(uint.MaxValue-100);
+        private readonly IDProvider m_IDProvider = new IDProvider();
         private readonly Dictionary<uint, CallAfterHandle> m_CallAfterHandles = new Dictionary<uint, CallAfterHandle>();
         private readonly List<Action> m_UpdateListeners = new List<Action>();
         private readonly List<CallAfterHandle> m_UpdateIterator = new List<CallAfterHandle>();

--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -153,8 +153,8 @@ namespace Anvil.CSharp.DelayedExecution
         /// CallAfterHandles are managed by the UpdateHandle and will be disposed if the UpdateHandle is disposed.
         /// </summary>
         /// <remarks>
-        /// CallAfterHandles usually operate on delta time but can easily be used to call after any type of delta. 
-        /// Example: <see cref="CallAfterUpdates(int, Action, uint)"/> is a convenience method that calls after a 
+        /// CallAfterHandles usually operate on delta time but can easily be used to call after any type of delta.
+        /// Example: <see cref="CallAfterUpdates(int, Action, uint)"/> is a convenience method that calls after a
         /// number of updates (usually frames).
         /// </remarks>
         /// <param name="targetDelta">The amount of delta (usually time) to wait until firing the callback function.</param>
@@ -212,4 +212,3 @@ namespace Anvil.CSharp.DelayedExecution
 
     }
 }
-

--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Anvil.CSharp.Core;
+using Anvil.CSharp.Data;
 
 namespace Anvil.CSharp.DelayedExecution
 {
@@ -21,8 +22,6 @@ namespace Anvil.CSharp.DelayedExecution
         /// </summary>
         public const uint CALL_AFTER_DEFAULT_CALL_LIMIT = 1;
 
-        private const uint CALL_AFTER_HANDLE_INITIAL_ID = 0;
-
         /// <summary>
         /// A <see cref="DeltaProvider"/> that provides a fixed delta of 1.
         /// </summary>
@@ -39,9 +38,11 @@ namespace Anvil.CSharp.DelayedExecution
             return updateHandle;
         }
 
-
-        private uint m_CallAfterHandleCurrentID = CALL_AFTER_HANDLE_INITIAL_ID;
-
+        // Arbitrary choice to warn when there are only 100 IDs left to provide.
+        // Seems likely that an application wouldn't need more than 100 more delayed calls before it can
+        // create a new UpdateHandle to work with.
+        // If this is an issue there's no risk to having the threshold trigger sooner.
+        private readonly IDProvider m_IDProvider = new IDProvider(UInt32.MaxValue-100);
         private readonly Dictionary<uint, CallAfterHandle> m_CallAfterHandles = new Dictionary<uint, CallAfterHandle>();
         private readonly List<Action> m_UpdateListeners = new List<Action>();
         private readonly List<CallAfterHandle> m_UpdateIterator = new List<CallAfterHandle>();
@@ -146,14 +147,6 @@ namespace Anvil.CSharp.DelayedExecution
             m_OnUpdate?.Invoke();
         }
 
-        private uint GetNextCallAfterHandleID()
-        {
-            uint id = m_CallAfterHandleCurrentID;
-            m_CallAfterHandleCurrentID++;
-
-            return id;
-        }
-
         /// <summary>
         /// Calls the provided callback after an arbitrary delta (usually time) via a <see cref="CallAfterHandle"/>.
         /// Delta is measured on each <see cref="OnUpdate"/> tick and the callback is called if the aggregated delta is >= the targetDelta.
@@ -174,11 +167,13 @@ namespace Anvil.CSharp.DelayedExecution
         /// <returns>A reference to the <see cref="CallAfterHandle"/> to store for use later. (Complete, Dispose)</returns>
         public CallAfterHandle CallAfter(float targetDelta, Action callback, DeltaProvider deltaProvider, uint callLimit = CALL_AFTER_DEFAULT_CALL_LIMIT)
         {
-            CallAfterHandle callAfterHandle = new CallAfterHandle(GetNextCallAfterHandleID(),
+            CallAfterHandle callAfterHandle = new CallAfterHandle(
+                m_IDProvider.GetNextID(),
                 callback,
                 targetDelta,
                 deltaProvider,
-                callLimit);
+                callLimit
+                );
 
             FinalizeHandle(callAfterHandle);
 

--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -42,7 +42,7 @@ namespace Anvil.CSharp.DelayedExecution
         // Seems likely that an application wouldn't need more than 100 more delayed calls before it can
         // create a new UpdateHandle to work with.
         // If this is an issue there's no risk to having the threshold trigger sooner.
-        private readonly IDProvider m_IDProvider = new IDProvider(UInt32.MaxValue-100);
+        private readonly IDProvider m_IDProvider = new IDProvider(uint.MaxValue-100);
         private readonly Dictionary<uint, CallAfterHandle> m_CallAfterHandles = new Dictionary<uint, CallAfterHandle>();
         private readonly List<Action> m_UpdateListeners = new List<Action>();
         private readonly List<CallAfterHandle> m_UpdateIterator = new List<CallAfterHandle>();


### PR DESCRIPTION
Add `IDProvider` which supplies unique IDs with a warning emitted when the supply is running low.
 - Update `UpdateHandle` to use `IDProvider`
 - Minor documentation formatting fixes.

### What is the current behaviour?
Each system that requires fast, simple, unique ID generation is left to implement the logic themselves. Leading to ad-hoc handling or no handling of ID supply exhaustion. 

### What is the new behaviour?
 `IDProvider` consolidates the logic to one implementation that is less error prone and can include more features in the future.

By using a single `IDProvider` applications can now easily identify when ID supply is running out at a global level and react accordingly. This is an extreme scenario but one that some applications must watch out for.
**Note:** IDs aren't shared between provider instances.

### What issues does this resolve?
None - This was ported over from an existing application and upgraded at the same time.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
