### PR TITLE
Logging - Improve evaluated assembly filter

### DIFF
--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21a135f2a6481ddb4f3b2c3dd1e04337b39a89f82d30136a36c839eb6cdb82a4
-size 12800
+oid sha256:ae9499c78c7a9d5490de5f142cb12ac39032f9812763221a2b75f622a17b1d6e
+size 12288


### PR DESCRIPTION
Improve the logic used to filter assemblies searched for default attributes. 
The new approach reduces the number of assemblies evaluated and won't require future maintenance if assembly names or anvil use contexts change.

**Tag Alongs**
  - Minor formatting and code style consistency changes.

### What is the current behaviour?
The assembly filtering logic uses a hard-coded list of assemblies to decide whether the assembly should be skipped.

### What is the new behaviour?
Assemblies are now filtered based on whether they reference the logging assembly or not. There's no point in searching an assembly for Logging attributes if it doesn't reference the Logging assembly.

Since this approach no longer relies on a hard-coded list it shouldn't require maintenance if/as the standard libraries change over time or the library is used in new contexts.

In the Unity project this was tested with the assemblies returned to have their types analyzed were:
**Previous Method: 27 assemblies**
```
Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
Assembly-CSharp-Editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-core-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-dots-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
myproject-rendering-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
myproject-simulaton-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-core-editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-csharp-core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-csharp-logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,

unity-inspector-help, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
Bee.BeeDriver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51,
PPv2URPConverters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
DOTween.Modules, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e,
DOTween, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e,
DOTweenEditor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e,
NugetForUnity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e,
PlayerBuildProgramLibrary.Data, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
ExCSS.Unity, Version=2.0.6.0, Culture=neutral, PublicKeyToken=null,
ScriptCompilationBuildProgram.Data, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
BeeBuildProgramCommon.Data, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
JetBrains.Rider.Unity.Editor.Plugin.Net46.Repacked, Version=2022.2.0.143, Culture=neutral, PublicKeyToken=null
```

**New Method: 10 assemblies**
```
Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
Assembly-CSharp-Editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-core-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-dots-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
myproject-rendering-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
myproject-simulaton-runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-core-editor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-csharp-core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-csharp-logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null,
anvil-unity-logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
```

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
