### PR TITLE
Logging - Log File Rotation

### DIFF
--- a/Logging/LogHandler/FileLogHandler.cs
+++ b/Logging/LogHandler/FileLogHandler.cs
@@ -19,7 +19,7 @@ namespace Anvil.CSharp.Logging
             /// </summary>
             Append,
             /// <summary>
-            /// A new log file is created each session, overwriting the previous one if it exists.
+            /// A new log file is created, overwriting the previous one if it exists.
             /// </summary>
             Replace,
         }

--- a/Logging/LogHandler/FileLogHandler.cs
+++ b/Logging/LogHandler/FileLogHandler.cs
@@ -131,10 +131,8 @@ namespace Anvil.CSharp.Logging
             m_TruncatedLogMessageByteCount = m_Writer.Encoding.GetByteCount(TRUNCATED_LOG_MESSAGE);
             m_NewlineByteCount = m_Writer.Encoding.GetByteCount(m_Writer.NewLine);
 
-            // Assert that the file size limit is reasonable value, at least longer than the truncation message
-            Debug.Assert(m_RotateFileSizeLimit >= m_TruncatedLogMessageByteCount);
-            // Assert that the file count limit is non-negative
-            Debug.Assert(m_RotateFileCountLimit >= 0);
+            Trace.Assert(m_RotateFileSizeLimit >= m_TruncatedLogMessageByteCount, "Invalid rotated file size limit");
+            Trace.Assert(m_RotateFileCountLimit >= 0, "Invalid rotated file count limit");
 
             if (m_WriteMode == WriteMode.Replace && m_RotateFileSizeLimit.HasValue)
             {


### PR DESCRIPTION
Implemented log file rotation (see linked issue for details) in `FileLogHandler`.

### What is the current behaviour?
Log files created by `FileLogHandler` may grow to indefinite size, especially with `append: true`.

### What is the new behaviour?
With file rotation enabled (which it is by default), after a log file reaches the set size limit, it is "rotated" (i.e. renamed with an index suffix) and a new file started.

### What issues does this resolve?
This prevents any one log file from becoming too large to reasonably work with.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No
_Note: Any existing uses of `FileLogHandler` will automatically begin using file rotation._

---

_Example logs generated under various use cases:_
![image](https://user-images.githubusercontent.com/1713664/189019720-38d9cb4f-9e72-4ce3-8460-a1337f155db0.png)

_Strict file size limit (rotate before the log that exceeds the limit)_
![image](https://user-images.githubusercontent.com/1713664/189487415-5645368d-e4de-4b87-bf90-b035c786ffb2.png)

### Updated Test Cases
- Re-tested every append/replace/rotate combination (as per first screenshot above)
- `RotateFileSizeLimit` is null/negative/zero/`long.MaxValue`
- `RotateFileCountLimit` is null/negative/zero/`int.MaxValue`
- Path contains folders that don't exist
- Unusual paths:
  - `path` has no file extension (ex. "log" -> "log.1", "log.2"...)
  - `path` already has an index (ex. "log.1.txt" -> "log.1.1.txt", "log.1.2.txt"...)
    - _Index is treated as part of the file name_
  - `path` ends with an index (ex. "log.1" -> "log.1.1", "log.2.1")
    - _Index is treated as the file extension_
- User manually modifies log files:
  - Gaps in rotated file indices
  - Duplicate indices (ex "log.1.txt" vs "log.01.txt")
  - Indices greater than `int.MaxValue` (ex. "log.123456789123456789.txt")