### PR TITLE
Logging polish

### DIFF
--- a/Logging/.CSProject/Log.cs
+++ b/Logging/.CSProject/Log.cs
@@ -11,6 +11,8 @@ namespace Anvil.CSharp.Logging
     /// </summary>
     public static class Log
     {
+        private const string UNKNOWN_CONTEXT = "unknown";
+
         private static readonly HashSet<ILogHandler> s_AdditionalHandlerList = new HashSet<ILogHandler>();
 
         /// <summary>
@@ -163,6 +165,9 @@ namespace Anvil.CSharp.Logging
 
             Debug.Assert(!string.IsNullOrEmpty(callerDerivedTypeName));
             Debug.Assert(!IsHandlingLog);
+
+            callerPath ??= UNKNOWN_CONTEXT;
+            callerName ??= UNKNOWN_CONTEXT;
 
             IsHandlingLog = true;
             foreach (ILogHandler handler in s_AdditionalHandlerList)

--- a/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
+++ b/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
@@ -19,7 +19,7 @@ namespace Anvil.CSharp.Logging
             string callerName,
             int callerLine)
         {
-            message = $"({Path.GetFileNameWithoutExtension(callerPath)}|{callerName}:{callerLine}) {message}";
+            message = $"({Path.GetFileNameWithoutExtension(callerPath)}:{callerLine}|{callerName}) {message}";
 
             switch (level)
             {

--- a/Logging/LogHandler/FileLogHandler.cs
+++ b/Logging/LogHandler/FileLogHandler.cs
@@ -75,13 +75,13 @@ namespace Anvil.CSharp.Logging
         ///  - <see cref="LOG_CONTEXT_CALLER_METHOD"/>
         ///  - <see cref="LOG_CONTEXT_CALLER_LINE"/>
         ///
-        /// Default: "({LOG_CONTEXT_CALLER_FILE}|{LOG_CONTEXT_CALLER_METHOD}:{LOG_CONTEXT_CALLER_LINE}) "
+        /// Default: "({LOG_CONTEXT_CALLER_FILE}:{LOG_CONTEXT_CALLER_LINE}|{LOG_CONTEXT_CALLER_METHOD}) "
         /// </summary>
         /// <example>
         /// The default format produces "(MyFile|MyCallingMethod:12) " for a log issued in the
         /// file "MyFile" from method "MyCallingMethod" on line "12".
         /// </example>
-        public string LogContextFormat { get; set; } = $"({LOG_CONTEXT_CALLER_FILE}|{LOG_CONTEXT_CALLER_METHOD}:{LOG_CONTEXT_CALLER_LINE}) ";
+        public string LogContextFormat { get; set; } = $"({LOG_CONTEXT_CALLER_FILE}:{LOG_CONTEXT_CALLER_LINE}|{LOG_CONTEXT_CALLER_METHOD}) ";
 
         /// <summary>
         /// Indicates the minimum message severity to handle. Logs below this level are ignored.

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae9499c78c7a9d5490de5f142cb12ac39032f9812763221a2b75f622a17b1d6e
-size 12288
+oid sha256:b2e033a3d7905cf9d8652d2f57bce61011f40f18876e548fcbdd4d294349566e
+size 11776


### PR DESCRIPTION
1. If log caller file/name are unknown, send "unknown" to log handlers instead of null
2. Changed log context format from `(FILE|METHOD:LINE)` to `(FILE:LINE|METHOD)`

Note: The default context string was initially going to be "\<unknown>" (with angle brackets), but each handler is expecting a file path and runs the given string through `Path.GetFileNameWithoutExtension()`, which throws an exception if given a string with invalid path characters. There are other options like "[unknown]" but for now I used no additional characters, as the text already stands out by being lowercase, beside the PascalCase of C# types/files.

### What is the current behaviour?
If for any reason a log's context fails to resolve, the context prepended to the message says `(|:0) message`

### What is the new behaviour?
If for any reason a log's context fails to resolve, the context will now say `(unknown:0|unknown) message`

### What issues does this resolve?
Improved log readability

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No

### Related
- https://github.com/decline-cookies/anvil-unity-core/pull/80
- https://github.com/decline-cookies/anvil-unity-core/issues/79