### PR TITLE
Hotfix id static reset

### DIFF
--- a/Data/ID/AbstractIDProvider.cs
+++ b/Data/ID/AbstractIDProvider.cs
@@ -72,8 +72,8 @@ namespace Anvil.CSharp.Data
 
             Log.GetLogger(this).Warning($"{GetType().Name} has passed its supply warning threshold. Threshold: {SupplyWarningThreshold:N0}");
             m_HasIDWarningTriggered = true;
-    
-            ID.IDLimitWarningEventArgs args = new ID.IDLimitWarningEventArgs();
+
+            ID.LimitWarningEventArgs args = new ID.LimitWarningEventArgs();
             DispatchIDLimitWarning(args);
             ID.DispatchOnIDLimitGlobalWarning(this, args);
         }
@@ -89,15 +89,16 @@ namespace Anvil.CSharp.Data
         /// Triggers the first time that <see cref="AbstractIDProvider{T}.SupplyWarningThreshold"/> is passed.
         /// This gives the consumer the opportunity to react before IDs are exhausted.
         /// </summary>
-        public event EventHandler<ID.IDLimitWarningEventArgs> OnIDLimitWarning;
+        public event EventHandler<ID.LimitWarningEventArgs> OnIDLimitWarning;
 
         protected override void DisposeSelf()
         {
             OnIDLimitWarning = null;
+            
             base.DisposeSelf();
         }
 
-        protected void DispatchIDLimitWarning(ID.IDLimitWarningEventArgs args)
+        protected void DispatchIDLimitWarning(ID.LimitWarningEventArgs args)
         {
             OnIDLimitWarning?.Invoke(this, args);
         }

--- a/Data/ID/ID.cs
+++ b/Data/ID/ID.cs
@@ -1,6 +1,5 @@
 using Anvil.CSharp.Logging;
 using System;
-using System.ComponentModel;
 
 namespace Anvil.CSharp.Data
 {

--- a/Data/ID/ID.cs
+++ b/Data/ID/ID.cs
@@ -51,6 +51,17 @@ namespace Anvil.CSharp.Data
         public static event EventHandler<IDLimitWarningEventArgs> OnIDLimitGlobalWarning;
         
         internal static void DispatchOnIDLimitGlobalWarning(object sender, IDLimitWarningEventArgs args)
+        /// <summary>
+        /// Resets the static state.
+        /// </summary>
+        /// <remarks>
+        /// Used for runtimes where a domain reload doesn't occur between run sessions (Ex: Unity).
+        /// </remarks>
+        public static void ResetState()
+        {
+            OnIDLimitGlobalWarning = null;
+        }
+
         {
             OnIDLimitGlobalWarning?.Invoke(sender, args);
         }

--- a/Data/ID/ID.cs
+++ b/Data/ID/ID.cs
@@ -1,5 +1,6 @@
 using Anvil.CSharp.Logging;
 using System;
+using System.ComponentModel;
 
 namespace Anvil.CSharp.Data
 {
@@ -8,7 +9,7 @@ namespace Anvil.CSharp.Data
         /// <summary>
         /// Arguments that describe an ID limit warning.
         /// </summary>
-        public class IDLimitWarningEventArgs : EventArgs
+        public class LimitWarningEventArgs : EventArgs
         {
             /// <summary>
             /// Indicates whether the limit warning has been handled. If true, no further corrective action is required
@@ -19,7 +20,7 @@ namespace Anvil.CSharp.Data
             /// <summary>
             /// Creates a new instance.
             /// </summary>
-            internal IDLimitWarningEventArgs()
+            internal LimitWarningEventArgs()
             {
                 IsHandled = false;
             }
@@ -48,9 +49,8 @@ namespace Anvil.CSharp.Data
         /// SupplyWarningThreshold for the first time.
         /// This gives the application the opportunity to react before IDs are exhausted.
         /// </summary>
-        public static event EventHandler<IDLimitWarningEventArgs> OnIDLimitGlobalWarning;
-        
-        internal static void DispatchOnIDLimitGlobalWarning(object sender, IDLimitWarningEventArgs args)
+        public static event EventHandler<LimitWarningEventArgs> OnIDLimitGlobalWarning;
+
         /// <summary>
         /// Resets the static state.
         /// </summary>
@@ -62,6 +62,7 @@ namespace Anvil.CSharp.Data
             OnIDLimitGlobalWarning = null;
         }
 
+        internal static void DispatchOnIDLimitGlobalWarning(object sender, LimitWarningEventArgs args)
         {
             OnIDLimitGlobalWarning?.Invoke(sender, args);
         }


### PR DESCRIPTION
Add a method to allow the static state of `ID` to be reset.
This is useful in run times that do not perform a domain reload between run instances (Ex Unity Editor).

#### Tag Alongs
 - Rename `ID.IDLimitWarningEventArgs` to `ID.LimitWarningEventArgs`. The outer class already qualifies the ID context of the type.

### What is the current behaviour?
Instances that do not correctly remove their listener from `ID.OnIDLimitWarning` when execution stops will be notified of event triggers for runtimes that do not perform a domain reload.

### What is the new behaviour?
Runtimes that do not perform a domain reload can now request `ID` to reset its static state.

### What issues does this resolve?
<!-- None is a perfectly valid answer -->
None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [x] Yes - Rename any references to `ID.IDLimitWarningEventArgs`
 - [ ] No
