### PR TITLE
Logging polish (part 2)

### DIFF
--- a/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
+++ b/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
@@ -23,11 +23,11 @@ namespace Anvil.CSharp.Logging
 
             if (callerLine > 0)
             {
-               message = $"({callerFile}:{callerLine}|{callerName}) {message}"
+               message = $"({callerFile}:{callerLine}|{callerName}) {message}";
             }
             else
             {
-               message = $"({callerFile}|{callerName}) {message}"
+               message = $"({callerFile}|{callerName}) {message}";
             }
 
             switch (level)

--- a/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
+++ b/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
@@ -21,9 +21,14 @@ namespace Anvil.CSharp.Logging
         {
             string callerFile = Path.GetFileNameWithoutExtension(callerPath);
 
-            string context = (callerLine > 0 ? $"{callerFile}:{callerLine}|{callerName}" : $"{callerFile}|{callerName}");
-
-            message = $"({context}) {message}";
+            if (callerLine > 0)
+            {
+               message = $"({callerFile}:{callerLine}|{callerName}) {message}"
+            }
+            else
+            {
+               message = $"({callerFile}|{callerName}) {message}"
+            }
 
             switch (level)
             {

--- a/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
+++ b/Logging/.CSProject/LogHandler/ConsoleLogHandler.cs
@@ -19,7 +19,11 @@ namespace Anvil.CSharp.Logging
             string callerName,
             int callerLine)
         {
-            message = $"({Path.GetFileNameWithoutExtension(callerPath)}:{callerLine}|{callerName}) {message}";
+            string callerFile = Path.GetFileNameWithoutExtension(callerPath);
+
+            string context = (callerLine > 0 ? $"{callerFile}:{callerLine}|{callerName}" : $"{callerFile}|{callerName}");
+
+            message = $"({context}) {message}";
 
             switch (level)
             {

--- a/Logging/LogHandler/FileLogHandler.cs
+++ b/Logging/LogHandler/FileLogHandler.cs
@@ -78,8 +78,8 @@ namespace Anvil.CSharp.Logging
         /// Default: "({LOG_CONTEXT_CALLER_FILE}:{LOG_CONTEXT_CALLER_LINE}|{LOG_CONTEXT_CALLER_METHOD}) "
         /// </summary>
         /// <example>
-        /// The default format produces "(MyFile|MyCallingMethod:12) " for a log issued in the
-        /// file "MyFile" from method "MyCallingMethod" on line "12".
+        /// The default format produces "(MyFile:12|MyCallingMethod) " for a log issued in the
+        /// file "MyFile" on line "12" from method "MyCallingMethod".
         /// </example>
         public string LogContextFormat { get; set; } = $"({LOG_CONTEXT_CALLER_FILE}:{LOG_CONTEXT_CALLER_LINE}|{LOG_CONTEXT_CALLER_METHOD}) ";
 

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2e033a3d7905cf9d8652d2f57bce61011f40f18876e548fcbdd4d294349566e
+oid sha256:17efa7f17c348289e7a6b3dcddfd9c6c9bbd7f559e98e9d7bfe3699287c46b14
 size 11776


### PR DESCRIPTION
1. Omit line number from log context when zero
2. Corrected outdated documentation comment

### What is the current behaviour?
Logs from managed code have line number zero in the context, ex: `(UnityLogListener:0|.ctor) message`

### What is the new behaviour?
Logs from managed code now omit the line number, ex: `(UnityLogListener|.ctor) message`

Note: The same functionality does not apply to `FileLogHandler` as it allows the user to define a log context format string, making it confusing if part of that format is silently omitted in some cases. It would be nearly impossible to cleanly omit the line number in custom format strings anyway.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [X] No

### Related
- https://github.com/decline-cookies/anvil-unity-core/pull/82