### PR TITLE
`anvil-csharp-logging.csproj` update from Framework 4.7.1 to Standard 2.1

### DIFF
--- a/Logging/.CSProject/anvil-csharp-logging.csproj
+++ b/Logging/.CSProject/anvil-csharp-logging.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Anvil.CSharp.Logging</RootNamespace>
     <AssemblyName>anvil-csharp-logging</AssemblyName>
     <LangVersion>8</LangVersion>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Logging/.CSProject/anvil-csharp-logging.csproj
+++ b/Logging/.CSProject/anvil-csharp-logging.csproj
@@ -1,35 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net471</TargetFramework>
-        <RootNamespace>Anvil.CSharp.Logging</RootNamespace>
-        <AssemblyName>anvil-csharp-logging</AssemblyName>
-        <LangVersion>8</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>../</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    </PropertyGroup>
-    
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>false</DebugSymbols>
-        <DebugType>None</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>../</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    </PropertyGroup>
-
-
+  <PropertyGroup>
+    <RootNamespace>Anvil.CSharp.Logging</RootNamespace>
+    <AssemblyName>anvil-csharp-logging</AssemblyName>
+    <LangVersion>8</LangVersion>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>../</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>../</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
 </Project>

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17efa7f17c348289e7a6b3dcddfd9c6c9bbd7f559e98e9d7bfe3699287c46b14
+oid sha256:21cf0c438188bf2b65f52c980a6f49efb04fe4d31995962adba06ad982c0b4e4
 size 11776


### PR DESCRIPTION
Updated the logging project to a modern `.csproj` targeting Standard 2.1

- In line with anvil-csharp-core project requirements
- Adds new *.deps.json required by modern .NET DLLs

### What issues does this resolve?
For pure C# projects in particular, some annoying, long-winded, and unskippable warnings about the log project targeting an older .NET Framework version appear every time you make a build. This update make `dotnet` happy and builds warning-free.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No