### PR TITLE
Type extension to get human-readable generic type names

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -19,11 +19,11 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Restore
-      run: dotnet restore anvil-csharp-core.csproj
+      run: dotnet restore
 
     - name: Build anvil-csharp-logging
       working-directory: Logging/.CSProject/
-      run: dotnet build --no-restore --configuration ${{ matrix.configuration }} anvil-csharp-logging.csproj
+      run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
 
     - name: Build anvil-csharp-core
-      run: dotnet build --no-restore --configuration ${{ matrix.configuration }} anvil-csharp-core.csproj
+      run: dotnet build --no-restore --configuration ${{ matrix.configuration }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,25 @@
+name: Unit Tests
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up .NET 6.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build anvil-csharp-core
+      run: dotnet build --no-restore
+
+    - name: Run unit Tests
+      run: dotnet test

--- a/Command/AbstractCommand.cs
+++ b/Command/AbstractCommand.cs
@@ -4,7 +4,7 @@ using Anvil.CSharp.Core;
 namespace Anvil.CSharp.Command
 {
     /// <summary>
-    /// Extension of <see cref="AbstractCommand"> to allow for strong typing <see cref="ICommand"> events.
+    /// Extension of <see cref="AbstractCommand" /> to allow for strong typing <see cref="ICommand" /> events.
     /// </summary>
     /// <typeparam name="T">The type of <see cref="ICommand"/> to use.</typeparam>
     public abstract class AbstractCommand<T> : AbstractCommand

--- a/Logging/.CSProject/Logger/Logger.cs
+++ b/Logging/.CSProject/Logger/Logger.cs
@@ -35,9 +35,7 @@ namespace Anvil.CSharp.Logging
             int removeCount = 1 + (type.GenericTypeArguments.Length < 10 ? 1 : 2);
             string name = type.Name[..^removeCount];
 
-            string genericTypeNames = type.GenericTypeArguments
-                .Select(GetReadableName)
-                .Aggregate((a, b) => $"{a}, {b}");
+            string genericTypeNames = string.Join(", ", type.GenericTypeArguments.Select(GetReadableName));
 
             return $"{name}<{genericTypeNames}>";
         }

--- a/Logging/.CSProject/Logger/Logger.cs
+++ b/Logging/.CSProject/Logger/Logger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Anvil.CSharp.Logging
@@ -14,6 +15,33 @@ namespace Anvil.CSharp.Logging
     /// </summary>
     public readonly struct Logger : ILogger
     {
+        // NOTE: This is a duplicate of Anvil.CSharp.Reflection.TypeExtension.GetReadableName
+        // because the logging namespace is isolated from the rest of Anvil, and thus cannot access that extension
+        private static readonly Type s_NullableType = typeof(Nullable<>);
+        private static string GetReadableName(Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return type.Name;
+            }
+
+            if (type.GetGenericTypeDefinition() == s_NullableType)
+            {
+                return $"{GetReadableName(type.GenericTypeArguments[0])}?";
+            }
+
+            // Remove the generic type count indicator (`n) from the type name
+            // Avoid having to calculate the number of digits in the generic type count by assuming it's under 100
+            int removeCount = 1 + (type.GenericTypeArguments.Length < 10 ? 1 : 2);
+            string name = type.Name[..^removeCount];
+
+            string genericTypeNames = type.GenericTypeArguments
+                .Select(GetReadableName)
+                .Aggregate((a, b) => $"{a}, {b}");
+
+            return $"{name}<{genericTypeNames}>";
+        }
+
         /// <summary>
         /// The name of the type this <see cref="Logger"/> represents.
         /// </summary>
@@ -31,7 +59,7 @@ namespace Anvil.CSharp.Logging
         /// An optional <see cref="string"/> to prefix to all messages through this logger.
         /// Useful when there are multiple types that share the same name which need to be differentiated.
         /// </param>
-        public Logger(Type type, string messagePrefix = null) : this(type.Name, messagePrefix) { }
+        public Logger(Type type, string messagePrefix = null) : this(GetReadableName(type), messagePrefix) { }
         /// <summary>
         /// Creates an instance of <see cref="Logger"/> from another instance.
         /// </summary>
@@ -40,7 +68,7 @@ namespace Anvil.CSharp.Logging
         /// An optional <see cref="string"/> to prefix to all messages through this logger.
         /// Useful when there are multiple instances or types that share the same name which need to be differentiated.
         /// </param>
-        public Logger(in object instance, string messagePrefix = null) : this(instance.GetType().Name, messagePrefix) { }
+        public Logger(in object instance, string messagePrefix = null) : this(instance.GetType(), messagePrefix) { }
 
         private Logger(string derivedTypeName, string messagePrefix)
         {

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:21cf0c438188bf2b65f52c980a6f49efb04fe4d31995962adba06ad982c0b4e4
-size 11776
+oid sha256:9b827b70f0154cea1dd978ff7f9fe4c2de4f2c1b79c50d4797765f2eac8ed092
+size 12288

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b827b70f0154cea1dd978ff7f9fe4c2de4f2c1b79c50d4797765f2eac8ed092
+oid sha256:a00335501a9699ccd18099cb4f789d7815299799b419b5ac83ec59246460abc8
 size 12288

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![License](https://img.shields.io/github/license/decline-cookies/anvil-csharp-core?label=License)&nbsp;&nbsp;&nbsp;
 ![.NET Build Status](https://github.com/decline-cookies/anvil-csharp-core/actions/workflows/dotnet-build.yml/badge.svg)&nbsp;&nbsp;&nbsp;
 ![Mono Build Status](https://github.com/decline-cookies/anvil-csharp-core/actions/workflows/mono-build.yml/badge.svg)&nbsp;&nbsp;&nbsp;
+![Unit Tests Status](https://github.com/decline-cookies/anvil-csharp-core/actions/workflows/unit-tests.yml/badge.svg)&nbsp;&nbsp;&nbsp;
 
 # anvil-csharp-core
 An opinionated collection of systems and utilities that help you build applications in C# quickly, coherently and ready to scale. While Anvil is designed with realtime interactive experiences in mind it's well suited as the foundation for any application or platform where flexibility is key.

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -43,6 +43,9 @@ namespace Anvil.CSharp.Reflection
         /// </summary>
         /// <param name="type">The type to get a readable name for.</param>
         /// <returns>The readable type name.</returns>
+        /// <remarks>
+        /// This function is duplicated in <see cref="Logger" /> until the DLL can be merged back into the main Anvil library.
+        /// </remarks>
         public static string GetReadableName(this Type type)
         {
             if (!type.IsGenericType)
@@ -60,9 +63,7 @@ namespace Anvil.CSharp.Reflection
             int removeCount = 1 + (type.GenericTypeArguments.Length < 10 ? 1 : 2);
             string name = type.Name[..^removeCount];
 
-            string genericTypeNames = type.GenericTypeArguments
-                .Select(arg => arg.GetReadableName())
-                .Aggregate((a, b) => $"{a}, {b}");
+            string genericTypeNames = string.Join(", ", type.GenericTypeArguments.Select(GetReadableName));
 
             return $"{name}<{genericTypeNames}>";
         }

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -37,7 +37,9 @@ namespace Anvil.CSharp.Reflection
         }
 
         /// <summary>
-        /// Gets a human-readble type name, similar to how the type appears in code. Primarily handles generic types.
+        /// Gets a human-readable type name, similar to how the type appears in code. Primarily handles generic types.
+        /// For example, instead of "List`1" or "System.Collections.Generic.List`1[System.Int32]", this helper will
+        /// return the name "List<Int32>"
         /// </summary>
         /// <param name="type">The type to get a readable name for.</param>
         /// <returns>The readable type name.</returns>

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using Anvil.CSharp.Reflection;
+
+namespace Anvil.CSharp.Tests
+{
+    public static class TypeExtensionTests
+    {
+        private class TestClass { }
+        private class TestGenericClass<T> { }
+        private class TestBigGenericClass<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> { }
+
+        [Test]
+        public static void GetReadableNameTest()
+        {
+            Assert.That(typeof(int).GetReadableName(), Is.EqualTo("Int32"));
+
+            Assert.That(typeof(int?).GetReadableName(), Is.EqualTo("Int32?"));
+
+            Assert.That(typeof(TestClass).GetReadableName(), Is.EqualTo("TestClass"));
+
+            Assert.That(typeof(TestGenericClass<int>).GetReadableName, Is.EqualTo("TestGenericClass<Int32>"));
+
+            Assert.That(typeof(TestGenericClass<int?>).GetReadableName, Is.EqualTo("TestGenericClass<Int32?>"));
+
+            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetReadableName(),
+                Is.EqualTo("TestGenericClass<TestGenericClass<TestClass>>"));
+
+            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetReadableName,
+                Is.EqualTo("TestBigGenericClass<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>"));
+        }
+    }
+}

--- a/Tests/anvil-csharp-tests.asmdef
+++ b/Tests/anvil-csharp-tests.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "anvil-csharp-tests",
     "rootNamespace": "Anvil.CSharp.Tests",
-    "references": [],
+    "references": [
+        "anvil-csharp-core"
+    ],
     "includePlatforms": [
         "Editor"
     ],


### PR DESCRIPTION
A type extension that handles generic types (and nullables) to generate a short human-readable type name, useful in logging.

_Note 1: It is not possible to format primitive types as they appear in code (i.e. `int` vs `Int32`) without access to `CSharpCodeProvider`, which Unity seems not to include, and would be expensive anyway. It seems sufficient to show the underlying type name for primitives anyway._

_Note 2: As mentioned in https://github.com/decline-cookies/anvil-csharp-core/issues/112, this change is inaccessible within the logging library, which therefore uses a static helper function that duplicates the type extension. A comment above said helper explains this._

### What is the current behaviour?
Calling `typeof(myObj).ToString()` with generics gives results like this:
```
Anvil.Unity.DOTS.Entities.Tasks.EntityProxyDataStream`1[DeclineCookies.TwistedDots.Game.Simulation.TimerInstance]
```

### What is the new behaviour?
Calling `typeof(myObj).GetReadableName()` will give results like this:
```
EntityProxyDataStream<TimerInstance>
```

### What issues does this resolve?
#112 - Type names are easier to read in logs, without the need for a custom formatter every time

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No

---

### Examples

Here is the output from a variety of example types after calling `GetReadableName()`:
```
TypeA
GenTypeA<String>
GenTypeA<Int32>
GenTypeA<Int32?>
GenTypeA<TypeA>
GenTypeA<List<String>>
GenTypeA<GenTypeA<GenTypeA<Int32>>>
GenTypeB<String, Int32>
GenTypeC<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>
NestedTypeA
NestedGenTypeA<String>
NestedGenTypeA<Int32>
NestedGenTypeA<Int32?>
NestedGenTypeA<TypeA>
NestedGenTypeA<NestedTypeA>
NestedGenTypeA<List<String>>
NestedGenTypeA<NestedGenTypeA<NestedGenTypeA<Int32>>>
NestedGenTypeB<String, Int32>
NestedGenTypeC<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>
```