### PR TITLE
Remove ignore of logging json deps file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ $RECYCLE.BIN/
 bin
 
 # anvil-csharp-core Specific
-Logging/anvil-csharp-logging.deps.json
+# None, so far...

--- a/Logging/anvil-csharp-logging.deps.json
+++ b/Logging/anvil-csharp-logging.deps.json
@@ -1,0 +1,47 @@
+{
+  "runtimeTarget": {
+    "name": ".NETStandard,Version=v2.1/",
+    "signature": ""
+  },
+  "compilationOptions": {},
+  "targets": {
+    ".NETStandard,Version=v2.1": {},
+    ".NETStandard,Version=v2.1/": {
+      "anvil-csharp-logging/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies": "1.0.2"
+        },
+        "runtime": {
+          "anvil-csharp-logging.dll": {}
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies/1.0.2": {
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.2"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.2": {}
+    }
+  },
+  "libraries": {
+    "anvil-csharp-logging/1.0.0": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.NETFramework.ReferenceAssemblies/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+      "path": "microsoft.netframework.referenceassemblies/1.0.2",
+      "hashPath": "microsoft.netframework.referenceassemblies.1.0.2.nupkg.sha512"
+    },
+    "Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8shzGaD5pZi4npuJYCM3de6pl0zlefcbyTIvXIiCdsTqauZ7lAhdaJVtJSqlhYid9VosFAOygBykoJ1SEOlGWA==",
+      "path": "microsoft.netframework.referenceassemblies.net461/1.0.2",
+      "hashPath": "microsoft.netframework.referenceassemblies.net461.1.0.2.nupkg.sha512"
+    }
+  }
+}


### PR DESCRIPTION
Per request at https://github.com/decline-cookies/anvil-unity-core/pull/86#issuecomment-1274976499
Remove `anvil-csharp-logging.deps.json` from `.gitignore` and add the generated file to the repo.

### What is the current behaviour?
`anvil-csharp-logging.deps.json` is not included in the repo.

### What is the new behaviour?
`anvil-csharp-logging.deps.json` is now included in the repo as recommended.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
