### PR TITLE
Mono Build Fix

### DIFF
--- a/.github/workflows/mono-build.yml
+++ b/.github/workflows/mono-build.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore anvil-csharp-core
       run: nuget restore anvil-csharp-core.csproj


### PR DESCRIPTION
### What is the current behaviour?
"Mono Build" GitHub Actions workflow is broken, builds don't even start

### What is the new behaviour?
Builds will maybe work now? Going to use this PR to test some things and find out.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No
