### PR TITLE
TypeExtension.GetReadableName Improvements

### DIFF
--- a/Logging/.CSProject/Logger/Logger.cs
+++ b/Logging/.CSProject/Logger/Logger.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace Anvil.CSharp.Logging
@@ -15,31 +14,6 @@ namespace Anvil.CSharp.Logging
     /// </summary>
     public readonly struct Logger : ILogger
     {
-        // NOTE: This is a duplicate of Anvil.CSharp.Reflection.TypeExtension.GetReadableName
-        // because the logging namespace is isolated from the rest of Anvil, and thus cannot access that extension
-        private static readonly Type s_NullableType = typeof(Nullable<>);
-        private static string GetReadableName(Type type)
-        {
-            if (!type.IsGenericType)
-            {
-                return type.Name;
-            }
-
-            if (type.GetGenericTypeDefinition() == s_NullableType)
-            {
-                return $"{GetReadableName(type.GenericTypeArguments[0])}?";
-            }
-
-            // Remove the generic type count indicator (`n) from the type name
-            // Avoid having to calculate the number of digits in the generic type count by assuming it's under 100
-            int removeCount = 1 + (type.GenericTypeArguments.Length < 10 ? 1 : 2);
-            string name = type.Name[..^removeCount];
-
-            string genericTypeNames = string.Join(", ", type.GenericTypeArguments.Select(GetReadableName));
-
-            return $"{name}<{genericTypeNames}>";
-        }
-
         /// <summary>
         /// The name of the type this <see cref="Logger"/> represents.
         /// </summary>
@@ -57,7 +31,7 @@ namespace Anvil.CSharp.Logging
         /// An optional <see cref="string"/> to prefix to all messages through this logger.
         /// Useful when there are multiple types that share the same name which need to be differentiated.
         /// </param>
-        public Logger(Type ownerType, string messagePrefix = null) : this(GetReadableName(ownerType), messagePrefix) { }
+        public Logger(Type ownerType, string messagePrefix = null) : this(ownerType.GetReadableName(), messagePrefix) { }
         /// <summary>
         /// Creates an instance of <see cref="Logger"/> for an object instance.
         /// </summary>

--- a/Logging/.CSProject/ReadabilityExtension.cs
+++ b/Logging/.CSProject/ReadabilityExtension.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Anvil.CSharp.Logging
+{
+    public static class ReadabilityExtension
+    {
+        private static readonly Type s_NullableType = typeof(Nullable<>);
+
+        /// <summary>
+        /// Gets a human-readable type name, similar to how the type appears in code. Primarily handles generic types.
+        /// For example, instead of "List`1" or "System.Collections.Generic.List`1[System.Int32]", this helper will
+        /// return the name "List<Int32>"
+        /// </summary>
+        /// <param name="type">The type to get a readable name for.</param>
+        /// <returns>The readable type name.</returns>
+        public static string GetReadableName(this Type type)
+        {
+            // type.IsGeneric will return true if the type itself or any outer type is generic.
+            if (!type.IsGenericType)
+            {
+                if (type.DeclaringType == null)
+                {
+                    return type.Name;
+                }
+
+                return $"{type.DeclaringType.GetReadableName()}.{type.Name}";
+            }
+
+            Type[] genericArgs = type.GenericTypeArguments;
+
+            return GetReadableNameOfGenericRecursive(type, genericArgs, genericArgs.Length);
+        }
+
+        /// <summary>
+        /// Traverses up a nested generic type's outer types to build a human readable name.
+        /// </summary>
+        /// <param name="type">The type to get a readable name for.</param>
+        /// <param name="genericArgs">
+        /// The generic arguments of the type ordered from outer to inner generic arguments.
+        /// Ex: MyType<genericArgs[0]>.MyInnerType<genericArgs[1]>
+        /// (The default order returned by <see cref="Type.GenericTypeArguments"/>
+        /// </param>
+        /// <param name="genericArgsUpperBound">
+        /// The upper bounds (exclusive) of the <see cref="genericArgs"/> array to evaluate
+        /// </param>
+        /// <returns>The readable type name.</returns>
+        /// <remarks>
+        /// For closed generic types the initial type is the only one with the concrete type args. This is why we pass
+        /// <see cref="genericArgs"/> through each recursion up through the outer types.
+        /// Since we recurse from inner to outer type the <see cref="genericArgsUpperBound"/> tracks the position in
+        /// the array that the current recursion should look to the left of for its generic args.
+        /// </remarks>
+        private static string GetReadableNameOfGenericRecursive(Type type, Type[] genericArgs, int genericArgsUpperBound)
+        {
+            int shallowGenericArgCount = type.GetShallowGenericTypeCount();
+            int genericArgsLowerBound = genericArgsUpperBound - shallowGenericArgCount;
+
+            Debug.Assert(genericArgsUpperBound <= genericArgs.Length);
+            Debug.Assert(genericArgsLowerBound >= 0);
+
+            // The path through any outer types
+            string outerTypes = null;
+            if (type.IsNested)
+            {
+                outerTypes = $"{GetReadableNameOfGenericRecursive(type.DeclaringType, genericArgs, genericArgsLowerBound)}.";
+            }
+
+            // If this type has no generic arguments just use the type name
+            if (shallowGenericArgCount == 0)
+            {
+                return string.Concat(outerTypes, type.Name);
+            }
+
+            if (type.GetGenericTypeDefinition() == s_NullableType)
+            {
+                return $"{outerTypes}{genericArgs[genericArgsLowerBound].GetReadableName()}?";
+            }
+
+            // Remove the generic type count indicator (`n) from the type name
+            int removeCount = 1 + shallowGenericArgCount.GetDigitCount();
+            string name = type.Name[..^removeCount];
+            IEnumerable<string> genericTypeArgNames = genericArgs
+                .Skip(genericArgsLowerBound)
+                .Take(shallowGenericArgCount)
+                .Select(arg => arg.GetReadableName());
+
+            return $"{outerTypes}{name}<{string.Join(", ", genericTypeArgNames)}>";
+        }
+
+        /// <summary>
+        /// Gets the number of generic arguments/parameters on a type without counting generic arguments on
+        /// surrounding types.
+        /// </summary>
+        /// <param name="type">The type to evaluate</param>
+        /// <returns>The number of generic arguments for the provided type ignoring any surrounding/outer types</returns>
+        /// <example>typeof(MyType<int>.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
+        /// <example>typeof(MyType.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
+        /// <example>typeof(MyType<int>.MyInnerType).GetShallowGenericTypeCount() => 0</example>
+        public static int GetShallowGenericTypeCount(this Type type)
+        {
+            if (type.IsNested)
+            {
+                return type.GetGenericArguments().Length - type.DeclaringType.GetGenericArguments().Length;
+            }
+            else
+            {
+                return type.GetGenericArguments().Length;
+            }
+        }
+
+        /// <summary>
+        /// Returns the number of digits in an integer.
+        /// Optionally, includes the negative sign in the count.
+        /// </summary>
+        /// <param name="value">The value to evaluate</param>
+        /// <param name="countSign">(default:false) If true, will increase the count by one for all numbers less than 0</param>
+        /// <returns>The number of digits in an integer</returns>
+        /// <remarks>Taken from: https://stackoverflow.com/a/51099524/640196</remarks>
+        public static int GetDigitCount(this int value, bool countSign = false)
+        {
+            if (value >= 0)
+            {
+                if (value < 10) return 1;
+                if (value < 100) return 2;
+                if (value < 1_000) return 3;
+                if (value < 10_000) return 4;
+                if (value < 100_000) return 5;
+                if (value < 1_000_000) return 6;
+                if (value < 10_000_000) return 7;
+                if (value < 100_000_000) return 8;
+                if (value < 1_000_000_000) return 9;
+                return 10;
+            }
+            else
+            {
+                int signCount = countSign ? 1 : 0;
+                if (value > -10) return signCount + 1;
+                if (value > -100) return signCount + 2;
+                if (value > -1_000) return signCount + 3;
+                if (value > -10_000) return signCount + 4;
+                if (value > -100_000) return signCount + 5;
+                if (value > -1_000_000) return signCount + 6;
+                if (value > -10_000_000) return signCount + 7;
+                if (value > -100_000_000) return signCount + 8;
+                if (value > -1_000_000_000) return signCount + 9;
+                return signCount + 10;
+            }
+        }
+    }
+}

--- a/Logging/anvil-csharp-logging.deps.json
+++ b/Logging/anvil-csharp-logging.deps.json
@@ -8,10 +8,19 @@
     ".NETStandard,Version=v2.1": {},
     ".NETStandard,Version=v2.1/": {
       "anvil-csharp-logging/1.0.0": {
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies": "1.0.2"
+        },
         "runtime": {
           "anvil-csharp-logging.dll": {}
         }
-      }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies/1.0.2": {
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.2"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.2": {}
     }
   },
   "libraries": {
@@ -19,6 +28,20 @@
       "type": "project",
       "serviceable": false,
       "sha512": ""
+    },
+    "Microsoft.NETFramework.ReferenceAssemblies/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+      "path": "microsoft.netframework.referenceassemblies/1.0.2",
+      "hashPath": "microsoft.netframework.referenceassemblies.1.0.2.nupkg.sha512"
+    },
+    "Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8shzGaD5pZi4npuJYCM3de6pl0zlefcbyTIvXIiCdsTqauZ7lAhdaJVtJSqlhYid9VosFAOygBykoJ1SEOlGWA==",
+      "path": "microsoft.netframework.referenceassemblies.net461/1.0.2",
+      "hashPath": "microsoft.netframework.referenceassemblies.net461.1.0.2.nupkg.sha512"
     }
   }
 }

--- a/Logging/anvil-csharp-logging.dll
+++ b/Logging/anvil-csharp-logging.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04849f45fba2855d3d9e94fff164ed1166dc9b4163a74fdae0d73b933ae10b17
-size 13824
+oid sha256:b2029329a71b51c8b91e9341d642a03a2a22ca57596d6fee17602a4d48001f8d
+size 14848

--- a/Mathematics/MathUtil.cs
+++ b/Mathematics/MathUtil.cs
@@ -43,44 +43,5 @@ namespace Anvil.CSharp.Mathematics
 
             return (--a);
         }
-
-        /// <summary>
-        /// Returns the number of digits in an integer.
-        /// Optionally, includes the negative sign in the count.
-        /// </summary>
-        /// <param name="value">The value to evaluate</param>
-        /// <param name="countSign">(default:false) If true, will increase the count by one for all numbers less than 0</param>
-        /// <returns>The number of digits in an integer</returns>
-        /// <remarks>Taken from: https://stackoverflow.com/a/51099524/640196</remarks>
-        public static int GetDigitCount(int value, bool countSign = false)
-        {
-            if (value >= 0)
-            {
-                if (value < 10) return 1;
-                if (value < 100) return 2;
-                if (value < 1_000) return 3;
-                if (value < 10_000) return 4;
-                if (value < 100_000) return 5;
-                if (value < 1_000_000) return 6;
-                if (value < 10_000_000) return 7;
-                if (value < 100_000_000) return 8;
-                if (value < 1_000_000_000) return 9;
-                return 10;
-            }
-            else
-            {
-                int signCount = countSign ? 1 : 0;
-                if (value > -10) return signCount + 1;
-                if (value > -100) return signCount + 2;
-                if (value > -1_000) return signCount + 3;
-                if (value > -10_000) return signCount + 4;
-                if (value > -100_000) return signCount + 5;
-                if (value > -1_000_000) return signCount + 6;
-                if (value > -10_000_000) return signCount + 7;
-                if (value > -100_000_000) return signCount + 8;
-                if (value > -1_000_000_000) return signCount + 9;
-                return signCount + 10;
-            }
-        }
     }
 }

--- a/Mathematics/MathUtil.cs
+++ b/Mathematics/MathUtil.cs
@@ -58,28 +58,28 @@ namespace Anvil.CSharp.Mathematics
             {
                 if (value < 10) return 1;
                 if (value < 100) return 2;
-                if (value < 1000) return 3;
-                if (value < 10000) return 4;
-                if (value < 100000) return 5;
-                if (value < 1000000) return 6;
-                if (value < 10000000) return 7;
-                if (value < 100000000) return 8;
-                if (value < 1000000000) return 9;
+                if (value < 1_000) return 3;
+                if (value < 10_000) return 4;
+                if (value < 100_000) return 5;
+                if (value < 1_000_000) return 6;
+                if (value < 10_000_000) return 7;
+                if (value < 100_000_000) return 8;
+                if (value < 1_000_000_000) return 9;
                 return 10;
             }
             else
             {
                 int signCount = countSign ? 1 : 0;
-                if (value > -10) return signCount + 2;
-                if (value > -100) return signCount + 3;
-                if (value > -1000) return signCount + 4;
-                if (value > -10000) return signCount + 5;
-                if (value > -100000) return signCount + 6;
-                if (value > -1000000) return signCount + 7;
-                if (value > -10000000) return signCount + 8;
-                if (value > -100000000) return signCount + 9;
-                if (value > -1000000000) return signCount + 10;
-                return signCount + 11;
+                if (value > -10) return signCount + 1;
+                if (value > -100) return signCount + 2;
+                if (value > -1_000) return signCount + 3;
+                if (value > -10_000) return signCount + 4;
+                if (value > -100_000) return signCount + 5;
+                if (value > -1_000_000) return signCount + 6;
+                if (value > -10_000_000) return signCount + 7;
+                if (value > -100_000_000) return signCount + 8;
+                if (value > -1_000_000_000) return signCount + 9;
+                return signCount + 10;
             }
         }
     }

--- a/Mathematics/MathUtil.cs
+++ b/Mathematics/MathUtil.cs
@@ -43,5 +43,44 @@ namespace Anvil.CSharp.Mathematics
 
             return (--a);
         }
+
+        /// <summary>
+        /// Returns the number of digits in an integer.
+        /// Optionally, includes the negative sign in the count.
+        /// </summary>
+        /// <param name="value">The value to evaluate</param>
+        /// <param name="countSign">(default:false) If true, will increase the count by one for all numbers less than 0</param>
+        /// <returns>The number of digits in an integer</returns>
+        /// <remarks>Taken from: https://stackoverflow.com/a/51099524/640196</remarks>
+        public static int GetDigitCount(int value, bool countSign = false)
+        {
+            if (value >= 0)
+            {
+                if (value < 10) return 1;
+                if (value < 100) return 2;
+                if (value < 1000) return 3;
+                if (value < 10000) return 4;
+                if (value < 100000) return 5;
+                if (value < 1000000) return 6;
+                if (value < 10000000) return 7;
+                if (value < 100000000) return 8;
+                if (value < 1000000000) return 9;
+                return 10;
+            }
+            else
+            {
+                int signCount = countSign ? 1 : 0;
+                if (value > -10) return signCount + 2;
+                if (value > -100) return signCount + 3;
+                if (value > -1000) return signCount + 4;
+                if (value > -10000) return signCount + 5;
+                if (value > -100000) return signCount + 6;
+                if (value > -1000000) return signCount + 7;
+                if (value > -10000000) return signCount + 8;
+                if (value > -100000000) return signCount + 9;
+                if (value > -1000000000) return signCount + 10;
+                return signCount + 11;
+            }
+        }
     }
 }

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Anvil.CSharp.Mathematics;
+using System.Diagnostics;
 
 namespace Anvil.CSharp.Reflection
 {
@@ -48,24 +51,98 @@ namespace Anvil.CSharp.Reflection
         /// </remarks>
         public static string GetReadableName(this Type type)
         {
+            // type.IsGeneric will return true if the type itself or any outer type is generic.
             if (!type.IsGenericType)
             {
-                return type.Name;
+                if (type.DeclaringType == null)
+                {
+                    return type.Name;
+                }
+
+                return $"{type.DeclaringType.GetReadableName()}.{type.Name}";
+            }
+
+            Type[] genericArgs = type.GenericTypeArguments;
+
+            return GetReadableNameOfGenericRecursive(type, genericArgs, genericArgs.Length);
+        }
+
+        /// <summary>
+        /// Traverses up a nested generic type's outer types to build a human readable name.
+        /// </summary>
+        /// <param name="type">The type to get a readable name for.</param>
+        /// <param name="genericArgs">
+        /// The generic arguments of the type ordered from outer to inner generic arguments.
+        /// Ex: MyType<genericArgs[0]>.MyInnerType<genericArgs[1]>
+        /// (The default order returned by <see cref="Type.GenericTypeArguments"/>
+        /// </param>
+        /// <param name="genericArgsUpperBound">
+        /// The upper bounds (exclusive) of the <see cref="genericArgs"/> array to evaluate
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>
+        /// For closed generic types the initial type is the only one with the concrete type args. This is why we pass
+        /// <see cref="genericArgs"/> through each recursion up through the outer types.
+        /// Since we recurse from inner to outer type the <see cref="genericArgsUpperBound"/> tracks the position in
+        /// the array that the current recursion should look to the left of for its generic args.
+        /// </remarks>
+        private static string GetReadableNameOfGenericRecursive(Type type, Type[] genericArgs, int genericArgsUpperBound)
+        {
+            int shallowGenericArgCount = type.GetShallowGenericTypeCount();
+            int genericArgsLowerBound = genericArgsUpperBound - shallowGenericArgCount;
+
+            Debug.Assert(genericArgsUpperBound <= genericArgs.Length);
+            Debug.Assert(genericArgsLowerBound >= 0);
+
+            // The path through any outer types
+            string outerTypes = null;
+            if (type.IsNested)
+            {
+                outerTypes = $"{GetReadableNameOfGenericRecursive(type.DeclaringType, genericArgs, genericArgsLowerBound)}.";
+            }
+
+            // If this type has no generic arguments just use the type name
+            if (shallowGenericArgCount == 0)
+            {
+                return string.Concat(outerTypes, type.Name);
             }
 
             if (type.GetGenericTypeDefinition() == s_NullableType)
             {
-                return $"{type.GenericTypeArguments[0].GetReadableName()}?";
+                return $"{outerTypes}{genericArgs[genericArgsLowerBound].GetReadableName()}?";
             }
 
             // Remove the generic type count indicator (`n) from the type name
             // Avoid having to calculate the number of digits in the generic type count by assuming it's under 100
-            int removeCount = 1 + (type.GenericTypeArguments.Length < 10 ? 1 : 2);
+            int removeCount = 1 + MathUtil.GetDigitCount(shallowGenericArgCount);
             string name = type.Name[..^removeCount];
+            IEnumerable<string> genericTypeArgNames = genericArgs
+                .Skip(genericArgsLowerBound)
+                .Take(shallowGenericArgCount)
+                .Select(arg => arg.GetReadableName());
 
-            string genericTypeNames = string.Join(", ", type.GenericTypeArguments.Select(GetReadableName));
+            return $"{outerTypes}{name}<{string.Join(", ", genericTypeArgNames)}>";
+        }
 
-            return $"{name}<{genericTypeNames}>";
+        /// <summary>
+        /// Gets the number of generic arguments/parameters on a type without counting generic arguments on
+        /// surrounding types.
+        /// </summary>
+        /// <param name="type">The type to evaluate</param>
+        /// <returns>The number of generic arguments for the provided type ignoring any surrounding/outer types</returns>
+        /// <example>typeof(MyType<int>.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
+        /// <example>typeof(MyType.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
+        /// <example>typeof(MyType<int>.MyInnerType).GetShallowGenericTypeCount() => 0</example>
+        public static int GetShallowGenericTypeCount(this Type type)
+        {
+            if (type.IsNested)
+            {
+                return type.GetGenericArguments().Length - type.DeclaringType.GetGenericArguments().Length;
+            }
+            else
+            {
+                return type.GetGenericArguments().Length;
+            }
         }
     }
 }

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -11,8 +11,6 @@ namespace Anvil.CSharp.Reflection
     /// </summary>
     public static class TypeExtension
     {
-        private static readonly Type s_NullableType = typeof(Nullable<>);
-
         /// <summary>
         /// Resolves the default value of a provided runtime type.
         /// The runtime equivalent of `default(MyType)`
@@ -37,112 +35,6 @@ namespace Anvil.CSharp.Reflection
         public static bool isStatic(this Type type)
         {
             return type.IsAbstract && type.IsSealed;
-        }
-
-        /// <summary>
-        /// Gets a human-readable type name, similar to how the type appears in code. Primarily handles generic types.
-        /// For example, instead of "List`1" or "System.Collections.Generic.List`1[System.Int32]", this helper will
-        /// return the name "List<Int32>"
-        /// </summary>
-        /// <param name="type">The type to get a readable name for.</param>
-        /// <returns>The readable type name.</returns>
-        /// <remarks>
-        /// This function is duplicated in <see cref="Logger" /> until the DLL can be merged back into the main Anvil
-        /// library.
-        /// </remarks>
-        public static string GetReadableName(this Type type)
-        {
-            // type.IsGeneric will return true if the type itself or any outer type is generic.
-            if (!type.IsGenericType)
-            {
-                if (type.DeclaringType == null)
-                {
-                    return type.Name;
-                }
-
-                return $"{type.DeclaringType.GetReadableName()}.{type.Name}";
-            }
-
-            Type[] genericArgs = type.GenericTypeArguments;
-
-            return GetReadableNameOfGenericRecursive(type, genericArgs, genericArgs.Length);
-        }
-
-        /// <summary>
-        /// Traverses up a nested generic type's outer types to build a human readable name.
-        /// </summary>
-        /// <param name="type">The type to get a readable name for.</param>
-        /// <param name="genericArgs">
-        /// The generic arguments of the type ordered from outer to inner generic arguments.
-        /// Ex: MyType<genericArgs[0]>.MyInnerType<genericArgs[1]>
-        /// (The default order returned by <see cref="Type.GenericTypeArguments"/>
-        /// </param>
-        /// <param name="genericArgsUpperBound">
-        /// The upper bounds (exclusive) of the <see cref="genericArgs"/> array to evaluate
-        /// </param>
-        /// <returns>The readable type name.</returns>
-        /// <remarks>
-        /// For closed generic types the initial type is the only one with the concrete type args. This is why we pass
-        /// <see cref="genericArgs"/> through each recursion up through the outer types.
-        /// Since we recurse from inner to outer type the <see cref="genericArgsUpperBound"/> tracks the position in
-        /// the array that the current recursion should look to the left of for its generic args.
-        /// </remarks>
-        private static string GetReadableNameOfGenericRecursive(Type type, Type[] genericArgs, int genericArgsUpperBound)
-        {
-            int shallowGenericArgCount = type.GetShallowGenericTypeCount();
-            int genericArgsLowerBound = genericArgsUpperBound - shallowGenericArgCount;
-
-            Debug.Assert(genericArgsUpperBound <= genericArgs.Length);
-            Debug.Assert(genericArgsLowerBound >= 0);
-
-            // The path through any outer types
-            string outerTypes = null;
-            if (type.IsNested)
-            {
-                outerTypes = $"{GetReadableNameOfGenericRecursive(type.DeclaringType, genericArgs, genericArgsLowerBound)}.";
-            }
-
-            // If this type has no generic arguments just use the type name
-            if (shallowGenericArgCount == 0)
-            {
-                return string.Concat(outerTypes, type.Name);
-            }
-
-            if (type.GetGenericTypeDefinition() == s_NullableType)
-            {
-                return $"{outerTypes}{genericArgs[genericArgsLowerBound].GetReadableName()}?";
-            }
-
-            // Remove the generic type count indicator (`n) from the type name
-            int removeCount = 1 + MathUtil.GetDigitCount(shallowGenericArgCount);
-            string name = type.Name[..^removeCount];
-            IEnumerable<string> genericTypeArgNames = genericArgs
-                .Skip(genericArgsLowerBound)
-                .Take(shallowGenericArgCount)
-                .Select(arg => arg.GetReadableName());
-
-            return $"{outerTypes}{name}<{string.Join(", ", genericTypeArgNames)}>";
-        }
-
-        /// <summary>
-        /// Gets the number of generic arguments/parameters on a type without counting generic arguments on
-        /// surrounding types.
-        /// </summary>
-        /// <param name="type">The type to evaluate</param>
-        /// <returns>The number of generic arguments for the provided type ignoring any surrounding/outer types</returns>
-        /// <example>typeof(MyType<int>.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
-        /// <example>typeof(MyType.MyInnerType<float>).GetShallowGenericTypeCount() => 1</example>
-        /// <example>typeof(MyType<int>.MyInnerType).GetShallowGenericTypeCount() => 0</example>
-        public static int GetShallowGenericTypeCount(this Type type)
-        {
-            if (type.IsNested)
-            {
-                return type.GetGenericArguments().Length - type.DeclaringType.GetGenericArguments().Length;
-            }
-            else
-            {
-                return type.GetGenericArguments().Length;
-            }
         }
     }
 }

--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -19,7 +19,7 @@ namespace Anvil.CSharp.Reflection
         /// </summary>
         /// <param name="type">The type to resolve the default value for</param>
         /// <returns>The default value for the given type</returns>
-        /// <remarks>Stolen from: https://stackoverflow.com/a/2490274 </remarks>
+        /// <remarks>Source: https://stackoverflow.com/a/2490274</remarks>
         public static object CreateDefaultValue(this Type type)
         {
             return type.IsValueType ? Activator.CreateInstance(type) : null;
@@ -47,7 +47,8 @@ namespace Anvil.CSharp.Reflection
         /// <param name="type">The type to get a readable name for.</param>
         /// <returns>The readable type name.</returns>
         /// <remarks>
-        /// This function is duplicated in <see cref="Logger" /> until the DLL can be merged back into the main Anvil library.
+        /// This function is duplicated in <see cref="Logger" /> until the DLL can be merged back into the main Anvil
+        /// library.
         /// </remarks>
         public static string GetReadableName(this Type type)
         {
@@ -79,7 +80,7 @@ namespace Anvil.CSharp.Reflection
         /// <param name="genericArgsUpperBound">
         /// The upper bounds (exclusive) of the <see cref="genericArgs"/> array to evaluate
         /// </param>
-        /// <returns></returns>
+        /// <returns>The readable type name.</returns>
         /// <remarks>
         /// For closed generic types the initial type is the only one with the concrete type args. This is why we pass
         /// <see cref="genericArgs"/> through each recursion up through the outer types.
@@ -113,7 +114,6 @@ namespace Anvil.CSharp.Reflection
             }
 
             // Remove the generic type count indicator (`n) from the type name
-            // Avoid having to calculate the number of digits in the generic type count by assuming it's under 100
             int removeCount = 1 + MathUtil.GetDigitCount(shallowGenericArgCount);
             string name = type.Name[..^removeCount];
             IEnumerable<string> genericTypeArgNames = genericArgs

--- a/Tests/Logging/ReadabilityExtensionTests.cs
+++ b/Tests/Logging/ReadabilityExtensionTests.cs
@@ -1,0 +1,103 @@
+using System;
+using Anvil.CSharp.Logging;
+using NUnit.Framework;
+
+namespace Anvil.CSharp.Tests.Logging
+{
+    public class ReadabilityExtensionTests
+    {
+        private class TestClass { }
+        private class TestGenericClass<T> { }
+        private class TestBigGenericClass<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> { }
+
+        private class TestOuterGenericNestedClass<T>
+        {
+            public class TestInnerClass { }
+
+            public class TestInnerGenericClass<InnerT> { }
+        }
+
+        [Test]
+        [Order(1)]
+        public static void GetShallowGenericTypeCount()
+        {
+            Assert.That(typeof(int).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(int?).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(TestGenericClass<int>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestGenericClass<int?>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetShallowGenericTypeCount(), Is.EqualTo(10));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public static void GetReadableNameTest()
+        {
+            Assert.That(typeof(int).GetReadableName(), Is.EqualTo("Int32"));
+
+            Assert.That(typeof(int?).GetReadableName(), Is.EqualTo("Int32?"));
+
+            Assert.That(typeof(TestClass).GetReadableName(), Is.EqualTo("ReadabilityExtensionTests.TestClass"));
+
+            Assert.That(typeof(TestGenericClass<int>).GetReadableName(), Is.EqualTo("ReadabilityExtensionTests.TestGenericClass<Int32>"));
+
+            Assert.That(typeof(TestGenericClass<int?>).GetReadableName(), Is.EqualTo("ReadabilityExtensionTests.TestGenericClass<Int32?>"));
+
+            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestGenericClass<ReadabilityExtensionTests.TestGenericClass<ReadabilityExtensionTests.TestClass>>"));
+
+            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestBigGenericClass<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerClass"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerGenericClass<Single>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerClass).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerClass"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerGenericClass<float?>).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerGenericClass<Single?>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<>.TestInnerGenericClass<>).GetReadableName(),
+                Is.EqualTo("ReadabilityExtensionTests.TestOuterGenericNestedClass<>.TestInnerGenericClass<>"));
+        }
+
+        [Test]
+        public static void GetDigitCount()
+        {
+            Assert.That(0.GetDigitCount(), Is.EqualTo(1));
+            Assert.That(0.GetDigitCount(true), Is.EqualTo(1));
+
+            TestValue(1, 1);
+
+            int iterations = (int)(Math.Log(int.MaxValue) / Math.Log(10));
+            for (int i = 1; i <= iterations; i++)
+            {
+                int val = (int)Math.Pow(10, i);
+                TestValue(val-1, i);   // Ex: 99, 2
+                TestValue(val, i+1);   // Ex: 100, 3
+            }
+
+            void TestValue(int positiveValue, int expectedDigits)
+            {
+                Assert.That(positiveValue.GetDigitCount(), Is.EqualTo(expectedDigits));
+                Assert.That(positiveValue.GetDigitCount(true), Is.EqualTo(expectedDigits));
+                Assert.That((-positiveValue).GetDigitCount(), Is.EqualTo(expectedDigits));
+                Assert.That((-positiveValue).GetDigitCount(true), Is.EqualTo(expectedDigits+1));
+            }
+        }
+    }
+}

--- a/Tests/Mathematics/MathUtilTests.cs
+++ b/Tests/Mathematics/MathUtilTests.cs
@@ -18,30 +18,5 @@ namespace Anvil.CSharp.Tests
 
             Assert.That(MathUtil.FindPrimeNumber(100), Is.EqualTo(541));
         }
-
-        [Test]
-        public static void GetDigitCount()
-        {
-            Assert.That(MathUtil.GetDigitCount(0), Is.EqualTo(1));
-            Assert.That(MathUtil.GetDigitCount(0, true), Is.EqualTo(1));
-
-            TestValue(1, 1);
-
-            int iterations = (int)(Math.Log(int.MaxValue) / Math.Log(10));
-            for (int i = 1; i <= iterations; i++)
-            {
-                int val = (int)Math.Pow(10, i);
-                TestValue(val-1, i);   // Ex: 99, 2
-                TestValue(val, i+1);   // Ex: 100, 3
-            }
-
-            void TestValue(int positiveValue, int expectedDigits)
-            {
-                Assert.That(MathUtil.GetDigitCount(positiveValue), Is.EqualTo(expectedDigits));
-                Assert.That(MathUtil.GetDigitCount(positiveValue, true), Is.EqualTo(expectedDigits));
-                Assert.That(MathUtil.GetDigitCount(-positiveValue), Is.EqualTo(expectedDigits));
-                Assert.That(MathUtil.GetDigitCount(-positiveValue, true), Is.EqualTo(expectedDigits+1));
-            }
-        }
     }
 }

--- a/Tests/Mathematics/MathUtilTests.cs
+++ b/Tests/Mathematics/MathUtilTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Anvil.CSharp.Mathematics;
+using NUnit.Framework;
+
+namespace Anvil.CSharp.Tests
+{
+    public static class MathUtilTests
+    {
+        [Test]
+        public static void FindPrimeNumber()
+        {
+            //TODO: #129 - There's probably a more NUnit way to do this
+            int[] primeNumbers = new[] { 1, 2, 3, 5, 7, 11, 13, 17, 19, 23 };
+            for (int i = 0; i < primeNumbers.Length; i++)
+            {
+                Assert.That(MathUtil.FindPrimeNumber(i), Is.EqualTo(primeNumbers[i]));
+            }
+
+            Assert.That(MathUtil.FindPrimeNumber(100), Is.EqualTo(541));
+        }
+
+        [Test]
+        public static void GetDigitCount()
+        {
+            Assert.That(MathUtil.GetDigitCount(0), Is.EqualTo(1));
+            Assert.That(MathUtil.GetDigitCount(0, true), Is.EqualTo(1));
+
+            TestValue(1, 1);
+
+            int iterations = (int)(Math.Log(int.MaxValue) / Math.Log(10));
+            for (int i = 1; i <= iterations; i++)
+            {
+                int val = (int)Math.Pow(10, i);
+                TestValue(val-1, i);   // Ex: 99, 2
+                TestValue(val, i+1);   // Ex: 100, 3
+            }
+
+            void TestValue(int positiveValue, int expectedDigits)
+            {
+                Assert.That(MathUtil.GetDigitCount(positiveValue), Is.EqualTo(expectedDigits));
+                Assert.That(MathUtil.GetDigitCount(positiveValue, true), Is.EqualTo(expectedDigits));
+                Assert.That(MathUtil.GetDigitCount(-positiveValue), Is.EqualTo(expectedDigits));
+                Assert.That(MathUtil.GetDigitCount(-positiveValue, true), Is.EqualTo(expectedDigits+1));
+            }
+        }
+    }
+}

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -9,6 +9,36 @@ namespace Anvil.CSharp.Tests
         private class TestGenericClass<T> { }
         private class TestBigGenericClass<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> { }
 
+        private class TestOuterGenericNestedClass<T>
+        {
+            public class TestInnerClass { }
+
+            public class TestInnerGenericClass<InnerT> { }
+        }
+
+        [Test]
+        [Order(1)]
+        public static void GetShallowGenericTypeCount()
+        {
+            Assert.That(typeof(int).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(int?).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(TestGenericClass<int>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestGenericClass<int?>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+
+            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetShallowGenericTypeCount(), Is.EqualTo(10));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetShallowGenericTypeCount(), Is.EqualTo(1));
+        }
+
         [Test]
         public static void GetReadableNameTest()
         {
@@ -16,17 +46,34 @@ namespace Anvil.CSharp.Tests
 
             Assert.That(typeof(int?).GetReadableName(), Is.EqualTo("Int32?"));
 
-            Assert.That(typeof(TestClass).GetReadableName(), Is.EqualTo("TestClass"));
+            Assert.That(typeof(TestClass).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestClass"));
 
-            Assert.That(typeof(TestGenericClass<int>).GetReadableName, Is.EqualTo("TestGenericClass<Int32>"));
+            Assert.That(typeof(TestGenericClass<int>).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestGenericClass<Int32>"));
 
-            Assert.That(typeof(TestGenericClass<int?>).GetReadableName, Is.EqualTo("TestGenericClass<Int32?>"));
+            Assert.That(typeof(TestGenericClass<int?>).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestGenericClass<Int32?>"));
 
             Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetReadableName(),
-                Is.EqualTo("TestGenericClass<TestGenericClass<TestClass>>"));
+                Is.EqualTo("TypeExtensionTests.TestGenericClass<TypeExtensionTests.TestGenericClass<TypeExtensionTests.TestClass>>"));
 
-            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetReadableName,
-                Is.EqualTo("TestBigGenericClass<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>"));
+            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestBigGenericClass<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerClass"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerGenericClass<Single>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerClass).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerClass"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerGenericClass<float?>).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerGenericClass<Single?>"));
+
+            Assert.That(typeof(TestOuterGenericNestedClass<>.TestInnerGenericClass<>).GetReadableName(),
+                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<>.TestInnerGenericClass<>"));
         }
+
+
     }
 }

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -1,78 +1,10 @@
-using NUnit.Framework;
-using Anvil.CSharp.Reflection;
+
 
 namespace Anvil.CSharp.Tests
 {
     public static class TypeExtensionTests
     {
-        private class TestClass { }
-        private class TestGenericClass<T> { }
-        private class TestBigGenericClass<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> { }
 
-        private class TestOuterGenericNestedClass<T>
-        {
-            public class TestInnerClass { }
-
-            public class TestInnerGenericClass<InnerT> { }
-        }
-
-        [Test]
-        [Order(1)]
-        public static void GetShallowGenericTypeCount()
-        {
-            Assert.That(typeof(int).GetShallowGenericTypeCount(), Is.EqualTo(0));
-
-            Assert.That(typeof(int?).GetShallowGenericTypeCount(), Is.EqualTo(1));
-
-            Assert.That(typeof(TestClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
-
-            Assert.That(typeof(TestGenericClass<int>).GetShallowGenericTypeCount(), Is.EqualTo(1));
-
-            Assert.That(typeof(TestGenericClass<int?>).GetShallowGenericTypeCount(), Is.EqualTo(1));
-
-            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetShallowGenericTypeCount(), Is.EqualTo(1));
-
-            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetShallowGenericTypeCount(), Is.EqualTo(10));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetShallowGenericTypeCount(), Is.EqualTo(0));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetShallowGenericTypeCount(), Is.EqualTo(1));
-        }
-
-        [Test]
-        public static void GetReadableNameTest()
-        {
-            Assert.That(typeof(int).GetReadableName(), Is.EqualTo("Int32"));
-
-            Assert.That(typeof(int?).GetReadableName(), Is.EqualTo("Int32?"));
-
-            Assert.That(typeof(TestClass).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestClass"));
-
-            Assert.That(typeof(TestGenericClass<int>).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestGenericClass<Int32>"));
-
-            Assert.That(typeof(TestGenericClass<int?>).GetReadableName(), Is.EqualTo("TypeExtensionTests.TestGenericClass<Int32?>"));
-
-            Assert.That(typeof(TestGenericClass<TestGenericClass<TestClass>>).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestGenericClass<TypeExtensionTests.TestGenericClass<TypeExtensionTests.TestClass>>"));
-
-            Assert.That(typeof(TestBigGenericClass<int, int, int, int, int, int, int, int, int, int>).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestBigGenericClass<Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32>"));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerClass).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerClass"));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int>.TestInnerGenericClass<float>).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32>.TestInnerGenericClass<Single>"));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerClass).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerClass"));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<int?>.TestInnerGenericClass<float?>).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<Int32?>.TestInnerGenericClass<Single?>"));
-
-            Assert.That(typeof(TestOuterGenericNestedClass<>.TestInnerGenericClass<>).GetReadableName(),
-                Is.EqualTo("TypeExtensionTests.TestOuterGenericNestedClass<>.TestInnerGenericClass<>"));
-        }
 
 
     }


### PR DESCRIPTION
Improved `TypeExtension.GetReadableName` to:
 - Include outer types in the names of inner types.
 - Correctly handle types with a generic outer type - `MyType<int>.MyInnerType`

## TODO
Once this is approved there is some work to do copying the changes.
 - [x] ~Copy `GetReadableName()` logic into the Logging DLL~

## Tag Alongs
 - `MathUtil.GetDigitCount` - Returns the number of digits in an int without needing to convert to string.
 - Add unit tests for `MathUtil`
    - For the prime number test I added some reasonable testing that should hit all code paths but checking that the first `int.MaxValue` prime numbers are correct is just making unreasonable work for the unit tests!

### What is the current behaviour?
`GetReadableName`
 -  Does not include the names of outer types on a given type.
 - Would generate an incorrect name when an inner type had a generic outer type
    - Ex: `MyType<int>.MyInnerType` would resolve to `MyInnerTy<int>`

### What is the new behaviour?
 - Outer types are included in the generated name
 - All combinations of generic and inner types are handled correctly
    - `MyType<int>.MyInnerType`
    - `MyType<int>.MyInnerType<float>`
    - `MyType.MyInnerType<float>`

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes
 - [ ] No

Migration instructions:
 - Any use of `TypeExtension.GetReadableName()` must now add `using Anvil.CSharp.Logging`
 - Any use of `MathUtil.GetDigitCount()` must now add `using Anvil.CSharp.Logging` and convert the use to an extension method.
    - Ex: `MathUtil.GetDigitCount(13)` is now `13.GetDigitCount()`

Breaking changes in other Anvil repos that depend on this one:
 - https://github.com/decline-cookies/anvil-unity-dots/pull/96