### PR TITLE
TypeExtensionTests - Implement

### DIFF
--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -1,10 +1,36 @@
-
+using NUnit.Framework;
+using Anvil.CSharp.Reflection;
 
 namespace Anvil.CSharp.Tests
 {
     public static class TypeExtensionTests
     {
+        private class TestClass { }
+        private sealed class TestSealedClass { }
+        private static class TestStaticClass { }
+        private abstract class TestAbstractClass { }
+        private struct TestStruct { }
 
+
+        [Test]
+        public static void CreateDefaultValue()
+        {
+            Assert.That(typeof(TestClass).CreateDefaultValue(), Is.EqualTo(null));
+            Assert.That(typeof(TestSealedClass).CreateDefaultValue(), Is.EqualTo(null));
+            Assert.That(typeof(TestStaticClass).CreateDefaultValue(), Is.EqualTo(null));
+            Assert.That(typeof(TestAbstractClass).CreateDefaultValue(), Is.EqualTo(null));
+            Assert.That(typeof(TestStruct).CreateDefaultValue(), Is.EqualTo(default(TestStruct)));
+        }
+
+        [Test]
+        public static void IsStatic()
+        {
+            Assert.That(typeof(TestClass).isStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestSealedClass).isStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestStaticClass).isStatic(), Is.EqualTo(true));
+            Assert.That(typeof(TestAbstractClass).isStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestStruct).isStatic(), Is.EqualTo(false));
+        }
 
 
     }


### PR DESCRIPTION
Add tests for the remaining `TypeExtension` methods

### What is the current behaviour?
`TypeExtension` does not have test coverage of `IsStatic()` and `CreateDefaultValue()`

### What is the new behaviour?
`TypeExtension` has full test coverage

### What issues does this resolve?
None

### What PRs does this depend on?
 - #130 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
