### PR TITLE
Tests - Add nunit assembly to asmdef

### DIFF
--- a/Tests/anvil-csharp-tests.asmdef
+++ b/Tests/anvil-csharp-tests.asmdef
@@ -2,17 +2,21 @@
     "name": "anvil-csharp-tests",
     "rootNamespace": "Anvil.CSharp.Tests",
     "references": [
-        "anvil-csharp-core"
+        "anvil-csharp-core",
+        ""
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "anvil-csharp-logging.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }


### PR DESCRIPTION
Add nUnit assembly reference to unit test ASMDef.

### What is the current behaviour?

Some nUnit features are not available because the DLL is not explicitly referenced (Ex: `TestFixtureAttribute`)
(at least not in Rider)

### What is the new behaviour?

IDE picks up on all attributes supported by nUnit

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
