### PR TITLE
Consistent Floating Point Tolerance

### DIFF
--- a/Mathematics/MathUtil.cs
+++ b/Mathematics/MathUtil.cs
@@ -1,10 +1,12 @@
 namespace Anvil.CSharp.Mathematics
 {
     /// <summary>
-    /// Useful helpers to aid in debugging
+    /// Useful math utilities
     /// </summary>
     public static class MathUtil
     {
+        public const float FLOATING_POINT_EQUALITY_TOLERANCE = 0.00001f;
+
         /// <summary>
         /// Calculates the Nth prime number that is passed in
         /// </summary>

--- a/Tests/Mathematics/MathUtilTests.cs
+++ b/Tests/Mathematics/MathUtilTests.cs
@@ -7,8 +7,10 @@ namespace Anvil.CSharp.Tests
     public static class MathUtilTests
     {
         [Test]
-        public static void FindPrimeNumber()
+        public static void FindPrimeNumberTest()
         {
+            Assert.That(nameof(FindPrimeNumberTest), Does.StartWith(nameof(MathUtil.FindPrimeNumber)));
+
             //TODO: #129 - There's probably a more NUnit way to do this
             int[] primeNumbers = new[] { 1, 2, 3, 5, 7, 11, 13, 17, 19, 23 };
             for (int i = 0; i < primeNumbers.Length; i++)


### PR DESCRIPTION
Adds a constant to define a floating point equality tolerance used by the math utilities and extensions coming to Anvil modules.
(coming soon!)

## Tag Along
 - Fix `FindPrimeNumberTest` name
 - Add test method name assertion to make sure test names are kept inline with method names if they get refactored.

### What is the current behaviour?
Floating point equality tolerance is either ad-hoc per platform or not evaluated at all.

### What is the new behaviour?
All math utilities doing equality checks on floating point values can check against the same precision.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
