### PR TITLE
TypeExtension.IsStatic name fix + Test Name Assertions

### DIFF
--- a/Reflection/TypeExtension.cs
+++ b/Reflection/TypeExtension.cs
@@ -32,7 +32,7 @@ namespace Anvil.CSharp.Reflection
         /// This works because a static class is defined as abstract, sealed at the IL level
         /// Source: https://stackoverflow.com/a/1175901/640196
         /// </remarks>
-        public static bool isStatic(this Type type)
+        public static bool IsStatic(this Type type)
         {
             return type.IsAbstract && type.IsSealed;
         }

--- a/Tests/Data/Collections/Util/Array2DExtensionTests.cs
+++ b/Tests/Data/Collections/Util/Array2DExtensionTests.cs
@@ -9,6 +9,8 @@ namespace Anvil.CSharp.Tests
         [Test, Order(0)]
         public static void PopulateTest()
         {
+            Assert.That(nameof(PopulateTest), Does.StartWith(nameof(Array2DExtension.Populate)));
+
             const int SIZE = 5;
 
             int[,] array = new int[SIZE, SIZE];
@@ -26,6 +28,8 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void GetLengthTest()
         {
+            Assert.That(nameof(GetLengthTest), Does.StartWith(nameof(Array2DExtension.GetLength)));
+
             Assert.That(new int[1, 1].GetLength(), Is.EqualTo((1, 1)));
             Assert.That(new int[2, 3].GetLength(), Is.EqualTo((2, 3)));
             Assert.That(new int[24, 42].GetLength(), Is.EqualTo((24, 42)));
@@ -34,6 +38,8 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void AnyAllTest()
         {
+            Assert.That(nameof(AnyAllTest), Does.Contain(nameof(Array2DExtension.All)).And.Contain(nameof(Array2DExtension.Any)));
+
             bool[,] array = new bool[5, 5];
             array.Populate((x, y) => true);
 
@@ -53,6 +59,8 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void ForEachTest()
         {
+            Assert.That(nameof(ForEachTest), Does.StartWith(nameof(Array2DExtension.ForEach)));
+
             const int SIZE = 5;
 
             int[,] array = new int[SIZE, SIZE];
@@ -67,19 +75,23 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void FindIndexTest()
         {
+            Assert.That(nameof(FindIndexTest), Does.StartWith(nameof(Array2DExtension.FindIndex)));
+
             const int SIZE = 5;
 
             int[,] array = new int[SIZE, SIZE];
             array.Populate((x, y) => x + SIZE*y);
 
             Assert.That(array.FindIndex(value => value == 13), Is.EqualTo((3, 2)));
-            
+
             Assert.That(array.FindIndex(value => value == -5), Is.EqualTo((-1, -1)));
         }
 
         [Test]
         public static void GetElementOrDefaultAtTest()
         {
+            Assert.That(nameof(GetElementOrDefaultAtTest), Does.StartWith(nameof(Array2DExtension.GetElementOrDefaultAt)));
+
             const int SIZE = 5;
 
             int[,] array = new int[SIZE, SIZE];

--- a/Tests/Data/Collections/Util/Array2DExtensionTests.cs
+++ b/Tests/Data/Collections/Util/Array2DExtensionTests.cs
@@ -9,7 +9,7 @@ namespace Anvil.CSharp.Tests
         [Test, Order(0)]
         public static void PopulateTest()
         {
-            Assert.That(nameof(PopulateTest), Does.StartWith(nameof(Array2DExtension.Populate)));
+            Assert.That(nameof(PopulateTest), Is.EqualTo(nameof(Array2DExtension.Populate) + "Test"));
 
             const int SIZE = 5;
 
@@ -28,7 +28,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void GetLengthTest()
         {
-            Assert.That(nameof(GetLengthTest), Does.StartWith(nameof(Array2DExtension.GetLength)));
+            Assert.That(nameof(GetLengthTest), Is.EqualTo(nameof(Array2DExtension.GetLength) + "Test"));
 
             Assert.That(new int[1, 1].GetLength(), Is.EqualTo((1, 1)));
             Assert.That(new int[2, 3].GetLength(), Is.EqualTo((2, 3)));
@@ -38,7 +38,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void AnyAllTest()
         {
-            Assert.That(nameof(AnyAllTest), Does.Contain(nameof(Array2DExtension.All)).And.Contain(nameof(Array2DExtension.Any)));
+            Assert.That(nameof(AnyAllTest), Is.EqualTo($"{nameof(Array2DExtension.Any)}{nameof(Array2DExtension.All)}Test"));
 
             bool[,] array = new bool[5, 5];
             array.Populate((x, y) => true);
@@ -59,7 +59,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void ForEachTest()
         {
-            Assert.That(nameof(ForEachTest), Does.StartWith(nameof(Array2DExtension.ForEach)));
+            Assert.That(nameof(ForEachTest), Is.EqualTo(nameof(Array2DExtension.ForEach) + "Test"));
 
             const int SIZE = 5;
 
@@ -75,7 +75,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void FindIndexTest()
         {
-            Assert.That(nameof(FindIndexTest), Does.StartWith(nameof(Array2DExtension.FindIndex)));
+            Assert.That(nameof(FindIndexTest), Is.EqualTo(nameof(Array2DExtension.FindIndex) + "Test"));
 
             const int SIZE = 5;
 
@@ -90,7 +90,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void GetElementOrDefaultAtTest()
         {
-            Assert.That(nameof(GetElementOrDefaultAtTest), Does.StartWith(nameof(Array2DExtension.GetElementOrDefaultAt)));
+            Assert.That(nameof(GetElementOrDefaultAtTest), Is.EqualTo(nameof(Array2DExtension.GetElementOrDefaultAt) + "Test"));
 
             const int SIZE = 5;
 

--- a/Tests/Logging/ReadabilityExtensionTests.cs
+++ b/Tests/Logging/ReadabilityExtensionTests.cs
@@ -21,6 +21,8 @@ namespace Anvil.CSharp.Tests.Logging
         [Order(1)]
         public static void GetShallowGenericTypeCount()
         {
+            Assert.That(nameof(GetShallowGenericTypeCount), Does.StartWith(nameof(ReadabilityExtension.GetShallowGenericTypeCount)));
+
             Assert.That(typeof(int).GetShallowGenericTypeCount(), Is.EqualTo(0));
 
             Assert.That(typeof(int?).GetShallowGenericTypeCount(), Is.EqualTo(1));
@@ -43,6 +45,8 @@ namespace Anvil.CSharp.Tests.Logging
         [Test]
         public static void GetReadableNameTest()
         {
+            Assert.That(nameof(GetReadableNameTest), Does.StartWith(nameof(ReadabilityExtension.GetReadableName)));
+
             Assert.That(typeof(int).GetReadableName(), Is.EqualTo("Int32"));
 
             Assert.That(typeof(int?).GetReadableName(), Is.EqualTo("Int32?"));
@@ -76,8 +80,10 @@ namespace Anvil.CSharp.Tests.Logging
         }
 
         [Test]
-        public static void GetDigitCount()
+        public static void GetDigitCountTest()
         {
+            Assert.That(nameof(GetDigitCountTest), Does.StartWith(nameof(ReadabilityExtension.GetDigitCount)));
+
             Assert.That(0.GetDigitCount(), Is.EqualTo(1));
             Assert.That(0.GetDigitCount(true), Is.EqualTo(1));
 

--- a/Tests/Logging/ReadabilityExtensionTests.cs
+++ b/Tests/Logging/ReadabilityExtensionTests.cs
@@ -19,9 +19,9 @@ namespace Anvil.CSharp.Tests.Logging
 
         [Test]
         [Order(1)]
-        public static void GetShallowGenericTypeCount()
+        public static void GetShallowGenericTypeCountTest()
         {
-            Assert.That(nameof(GetShallowGenericTypeCount), Does.StartWith(nameof(ReadabilityExtension.GetShallowGenericTypeCount)));
+            Assert.That(nameof(GetShallowGenericTypeCountTest), Is.EqualTo(nameof(ReadabilityExtension.GetShallowGenericTypeCount) + "Test"));
 
             Assert.That(typeof(int).GetShallowGenericTypeCount(), Is.EqualTo(0));
 
@@ -45,7 +45,7 @@ namespace Anvil.CSharp.Tests.Logging
         [Test]
         public static void GetReadableNameTest()
         {
-            Assert.That(nameof(GetReadableNameTest), Does.StartWith(nameof(ReadabilityExtension.GetReadableName)));
+            Assert.That(nameof(GetReadableNameTest), Is.EqualTo(nameof(ReadabilityExtension.GetReadableName) + "Test"));
 
             Assert.That(typeof(int).GetReadableName(), Is.EqualTo("Int32"));
 
@@ -82,7 +82,7 @@ namespace Anvil.CSharp.Tests.Logging
         [Test]
         public static void GetDigitCountTest()
         {
-            Assert.That(nameof(GetDigitCountTest), Does.StartWith(nameof(ReadabilityExtension.GetDigitCount)));
+            Assert.That(nameof(GetDigitCountTest), Is.EqualTo(nameof(ReadabilityExtension.GetDigitCount) + "Test"));
 
             Assert.That(0.GetDigitCount(), Is.EqualTo(1));
             Assert.That(0.GetDigitCount(true), Is.EqualTo(1));

--- a/Tests/Mathematics/MathUtilTests.cs
+++ b/Tests/Mathematics/MathUtilTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Anvil.CSharp.Mathematics;
 using NUnit.Framework;
 
@@ -9,7 +8,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void FindPrimeNumberTest()
         {
-            Assert.That(nameof(FindPrimeNumberTest), Does.StartWith(nameof(MathUtil.FindPrimeNumber)));
+            Assert.That(nameof(FindPrimeNumberTest), Is.EqualTo(nameof(MathUtil.FindPrimeNumber) + "Test"));
 
             //TODO: #129 - There's probably a more NUnit way to do this
             int[] primeNumbers = new[] { 1, 2, 3, 5, 7, 11, 13, 17, 19, 23 };

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -15,7 +15,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void CreateDefaultValueTest()
         {
-            Assert.That(nameof(CreateDefaultValueTest), Does.StartWith(nameof(TypeExtension.CreateDefaultValue)));
+            Assert.That(nameof(CreateDefaultValueTest), Is.EqualTo(nameof(TypeExtension.CreateDefaultValue) + "Test"));
 
             Assert.That(typeof(TestClass).CreateDefaultValue(), Is.EqualTo(null));
             Assert.That(typeof(TestSealedClass).CreateDefaultValue(), Is.EqualTo(null));
@@ -27,7 +27,7 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void IsStaticTest()
         {
-            Assert.That(nameof(IsStaticTest), Does.StartWith(nameof(TypeExtension.IsStatic)));
+            Assert.That(nameof(IsStaticTest), Is.EqualTo(nameof(TypeExtension.IsStatic) + "Test"));
 
             Assert.That(typeof(TestClass).IsStatic(), Is.EqualTo(false));
             Assert.That(typeof(TestSealedClass).IsStatic(), Is.EqualTo(false));

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -13,8 +13,10 @@ namespace Anvil.CSharp.Tests
 
 
         [Test]
-        public static void CreateDefaultValue()
+        public static void CreateDefaultValueTest()
         {
+            Assert.That(nameof(CreateDefaultValueTest), Does.StartWith(nameof(TypeExtension.CreateDefaultValue)));
+
             Assert.That(typeof(TestClass).CreateDefaultValue(), Is.EqualTo(null));
             Assert.That(typeof(TestSealedClass).CreateDefaultValue(), Is.EqualTo(null));
             Assert.That(typeof(TestStaticClass).CreateDefaultValue(), Is.EqualTo(null));
@@ -25,6 +27,8 @@ namespace Anvil.CSharp.Tests
         [Test]
         public static void IsStaticTest()
         {
+            Assert.That(nameof(IsStaticTest), Does.StartWith(nameof(TypeExtension.IsStatic)));
+
             Assert.That(typeof(TestClass).IsStatic(), Is.EqualTo(false));
             Assert.That(typeof(TestSealedClass).IsStatic(), Is.EqualTo(false));
             Assert.That(typeof(TestStaticClass).IsStatic(), Is.EqualTo(true));

--- a/Tests/Reflection/TypeExtensionTests.cs
+++ b/Tests/Reflection/TypeExtensionTests.cs
@@ -23,13 +23,13 @@ namespace Anvil.CSharp.Tests
         }
 
         [Test]
-        public static void IsStatic()
+        public static void IsStaticTest()
         {
-            Assert.That(typeof(TestClass).isStatic(), Is.EqualTo(false));
-            Assert.That(typeof(TestSealedClass).isStatic(), Is.EqualTo(false));
-            Assert.That(typeof(TestStaticClass).isStatic(), Is.EqualTo(true));
-            Assert.That(typeof(TestAbstractClass).isStatic(), Is.EqualTo(false));
-            Assert.That(typeof(TestStruct).isStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestClass).IsStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestSealedClass).IsStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestStaticClass).IsStatic(), Is.EqualTo(true));
+            Assert.That(typeof(TestAbstractClass).IsStatic(), Is.EqualTo(false));
+            Assert.That(typeof(TestStruct).IsStatic(), Is.EqualTo(false));
         }
 
 


### PR DESCRIPTION
- `TypeExtension.IsStatic` did not have the correct name casing
- Add test method name assertions to make sure test names are kept inline with method names if they get refactored.

### What is the current behaviour?
- `TypeExtension.isStatic` is not the correct naming convention
- Refactored methods that have unit tests may not have their test names updated. 

### What is the new behaviour?
- `TypeExtension.IsStatic`...promoted that `I`
- New assertions ensure that tests fail if a test's method name isn't updated to reflect the name of the method it is testing.

### What issues does this resolve?
None

### What PRs does this depend on?
 - #136 

### Does this introduce a breaking change?
 - [x] Yes - Any calls to `isStatic` should be changed to `IsStatic`
 - [ ] No
