### PR TITLE
Add ReadOnlyObservableCollection alias

### DIFF
--- a/Collections/ReadOnlyObservableCollection.cs
+++ b/Collections/ReadOnlyObservableCollection.cs
@@ -1,0 +1,27 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace Anvil.CSharp.Collections
+{
+    /// <summary>
+    /// An alias of <see cref="System.Collections.ObjectModel.ReadOnlyObservableCollection{T}"/> that exposes
+    /// <see cref="System.Collections.ObjectModel.ReadOnlyObservableCollection{T}.CollectionChanged"/>.
+    /// </summary>
+    /// <typeparam name="T">The collection's element type</typeparam>
+    /// <remarks>
+    /// Required because .NET doesn't currently want to introduce a binary breaking change
+    /// https://github.com/dotnet/runtime/issues/14267
+    /// </remarks>
+    public class ReadOnlyObservableCollection<T> : System.Collections.ObjectModel.ReadOnlyObservableCollection<T>
+    {
+        /// <inheritdoc cref="INotifyCollectionChanged.CollectionChanged"/>
+        public new event NotifyCollectionChangedEventHandler CollectionChanged
+        {
+            add => base.CollectionChanged += value;
+            remove => base.CollectionChanged -= value;
+        }
+
+        /// <inheritdoc cref="System.Collections.ObjectModel.ReadOnlyObservableCollection{T}"/>
+        public ReadOnlyObservableCollection(ObservableCollection<T> list) : base(list) { }
+    }
+}


### PR DESCRIPTION
Add an alias of `System.Collections.ObjectModel.ReadOnlyObservableCollection<T>` that exposes the `CollectionChanged` event.

### What is the current behaviour?

There is no way to listen to change events on `System.Collections.ObjectModel.ReadOnlyObservableCollection<T>` as you are with every other observable collection.

It's unlikely this will be fixed in .NET anytime soon. They are adverse to any binary breaking changes.
https://github.com/dotnet/runtime/issues/14267

### What is the new behaviour?

`Anvil.CSharp.Collections.ReadOnlyObservableCollection<T>` may be used in place for `System.Collections.ObjectModel.ReadOnlyObservableCollection<T>` in order to listen to the `CollectionChanged` event.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
