### PR TITLE
Implement `DeferredWorkPump`

### DIFF
--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -33,7 +33,7 @@ namespace Anvil.CSharp.DelayedExecution
         /// </param>
         public DeferredWorkPump(bool willEagerExecuteWork = false)
         {
-            m_ExecutePendingWorkStrategy = willEagerExecuteWork ? ExecutePendingWork_Eager : ExecutePendingWork;
+            m_ExecutePendingWorkStrategy = willEagerExecuteWork ? (Action)ExecutePendingWork_Eager : ExecutePendingWork;
 
             m_Update = UpdateHandle.Create<T>();
             m_PendingWork = new Queue<Action>();

--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Anvil.CSharp.Core;
+
+namespace Anvil.CSharp.DelayedExecution
+{
+    /// <summary>
+    /// Facilitates accumulating and deferring work to be executed at a specific, periodic, moment dictated by an
+    /// <see cref="AbstractUpdateSource"/>
+    /// </summary>
+    /// <typeparam name="T">The update source to schedule work against.</typeparam>
+    public class DeferredWorkPump<T> : AbstractAnvilBase where T : AbstractUpdateSource
+    {
+        private readonly Action m_ExecutePendingWorkStrategy;
+        private readonly Queue<Action> m_PendingWork;
+        private readonly UpdateHandle m_Update;
+        private CallAfterHandle m_PendingWorkRequestHandle;
+
+        /// <summary>
+        /// Returns true if the accumulated work is currently executing.
+        /// </summary>
+        public bool IsExecutingWork
+        {
+            get => m_Update.IsUpdating;
+        }
+
+        /// <summary>
+        /// Creates an instance of the work pump.
+        /// </summary>
+        /// <param name="willEagerExecuteWork">
+        /// (optional) If true, the work scheduled while executing accumulated work will get executed during the same
+        /// update.Otherwise, the work is deferred to the next update.
+        /// </param>
+        public DeferredWorkPump(bool willEagerExecuteWork = false)
+        {
+            m_ExecutePendingWorkStrategy = willEagerExecuteWork ? ExecutePendingWork_Eager : ExecutePendingWork;
+
+            m_Update = UpdateHandle.Create<T>();
+            m_PendingWork = new Queue<Action>();
+        }
+
+        protected override void DisposeSelf()
+        {
+            m_Update.Dispose();
+
+            base.DisposeSelf();
+        }
+
+        /// <summary>
+        /// Schedules work to be executed during the next update phase.
+        /// </summary>
+        /// <param name="work"></param>
+        public void ScheduleWork(Action work)
+        {
+            m_PendingWork.Enqueue(work);
+            m_PendingWorkRequestHandle ??= m_Update.CallAfterUpdates(0, m_ExecutePendingWorkStrategy);
+        }
+
+        private void ExecutePendingWork()
+        {
+            // Cache the count before iterating so any new work scheduled during the current import work is pushed
+            // off to the next update.
+            m_PendingWorkRequestHandle = null;
+            int count = m_PendingWork.Count;
+
+            for (int i = 0; i < count; i++)
+            {
+                m_PendingWork.Dequeue()();
+            }
+        }
+
+        private void ExecutePendingWork_Eager()
+        {
+            while (m_PendingWork.Count > 0)
+            {
+                m_PendingWork.Dequeue()();
+            }
+
+            m_PendingWorkRequestHandle = null;
+        }
+    }
+}

--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -79,12 +79,16 @@ namespace Anvil.CSharp.DelayedExecution
         }
 
         /// <summary>
-        /// Indicates whether the handle is currently executing its OnUpdate phase.
+        /// Indicates whether the handle's <see cref="UpdateSource"/> is currently executing its OnUpdate phase.
         /// </summary>
         public bool IsSourceUpdating
         {
             get => m_UpdateSource != null && m_UpdateSource.IsUpdating;
         }
+        /// <summary>
+        /// Indicates whether the handle is currently executing its OnUpdate phase.
+        /// </summary>
+        public bool IsUpdating { get; private set; }
 
         private UpdateHandle(Type updateSourceType)
         {
@@ -128,6 +132,9 @@ namespace Anvil.CSharp.DelayedExecution
 
         private void UpdateSource_OnUpdate()
         {
+            Debug.Assert(!IsUpdating);
+            IsUpdating = true;
+
             if (m_CallAfterHandles.Count > 0)
             {
                 //Take a snapshot of CallAfterHandles valid for this frame to iterate through since m_CallAfterHandles
@@ -141,6 +148,9 @@ namespace Anvil.CSharp.DelayedExecution
             }
 
             m_OnUpdate?.Invoke();
+
+            Debug.Assert(IsUpdating);
+            IsUpdating = false;
         }
 
         /// <summary>


### PR DESCRIPTION
Introduce a mechanism to defer work to a pre-defined, periodic, update phase.

#### Tag Alongs
 - Add `UpdateHandle.IsUpdating` to indicate whether the specific update handle instance is being updated.
    - This is in contrast to `UpdateHandle.IsSourceUpdating` which indicates whether the update source is currently updating for all `UpdateHandle`s listening to the same source.

### What is the current behaviour?
Developers must devise their own approach to deferring and accumulating work to a periodic update phase. This usually means defining an `UpdateHandle`, `Queue` and optionally tracking whether an update is scheduled.

### What is the new behaviour?
`DeferredWorkPump` is configured to update based on a user defined `AbstractUpdateSource`. Work may then be scheudled and accumulated against the `DeferredWorkPump` to be automatically executed at the desired update phase.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
