### PR TITLE
Add DeferredDataPump

### DIFF
--- a/DelayedExecution/DeferredDataPump.cs
+++ b/DelayedExecution/DeferredDataPump.cs
@@ -71,9 +71,10 @@ namespace Anvil.CSharp.DelayedExecution
 
         private void ProcessPendingData()
         {
+            // (IEnumerator<TDataType>) cast is required for <C# 9.0 compatibility. (CS8957)
             using IEnumerator<TDataType> enumerator = m_WillEagerExecuteDeferredData
-                ? new EagerDestructiveQueueEnumerator(m_PendingData)
-                : new SnapshotDestructiveQueueEnumerator(m_PendingData);
+                ? (IEnumerator<TDataType>) new EagerDestructiveQueueEnumerator(m_PendingData)
+                : (IEnumerator<TDataType>) new SnapshotDestructiveQueueEnumerator(m_PendingData);
 
             m_ProcessPendingData(enumerator);
 

--- a/DelayedExecution/DeferredDataPump.cs
+++ b/DelayedExecution/DeferredDataPump.cs
@@ -6,6 +6,12 @@ using Anvil.CSharp.Core;
 
 namespace Anvil.CSharp.DelayedExecution
 {
+    /// <summary>
+    /// Facilitates accumulating and deferring data to be processed at a specific, periodic, moment dictated by an
+    /// <see cref="AbstractUpdateSource"/>.
+    /// </summary>
+    /// <typeparam name="TUpdateSource">The update source to schedule data against.</typeparam>
+    /// <typeparam name="TDataType">The type of data to accumulate.</typeparam>
     public class DeferredDataPump<TUpdateSource, TDataType> : AbstractAnvilBase where TUpdateSource : AbstractUpdateSource
     {
         private readonly Action<IEnumerator<TDataType>> m_ProcessPendingData;

--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -19,6 +19,12 @@ namespace Anvil.CSharp.DelayedExecution
         /// </param>
         public DeferredWorkPump(bool willEagerExecuteWork = false) : base(ExecutePendingWork, willEagerExecuteWork) { }
 
+        /// <inheritdoc cref="DeferredDataPump{TUpdateSource,TDataType}.Schedule"/>
+        public new void Schedule(Action work)
+        {
+            base.Schedule(work);
+        }
+
         private static void ExecutePendingWork(IEnumerator<Action> pendingWork)
         {
             while (pendingWork.MoveNext())

--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Anvil.CSharp.Core;
 
 namespace Anvil.CSharp.DelayedExecution
 {
@@ -9,21 +8,8 @@ namespace Anvil.CSharp.DelayedExecution
     /// <see cref="AbstractUpdateSource"/>
     /// </summary>
     /// <typeparam name="T">The update source to schedule work against.</typeparam>
-    public class DeferredWorkPump<T> : AbstractAnvilBase where T : AbstractUpdateSource
+    public class DeferredWorkPump<TUpdateSource> : DeferredDataPump<TUpdateSource, Action> where TUpdateSource : AbstractUpdateSource
     {
-        private readonly Action m_ExecutePendingWorkStrategy;
-        private readonly Queue<Action> m_PendingWork;
-        private readonly UpdateHandle m_Update;
-        private CallAfterHandle m_PendingWorkRequestHandle;
-
-        /// <summary>
-        /// Returns true if the accumulated work is currently executing.
-        /// </summary>
-        public bool IsExecutingWork
-        {
-            get => m_Update.IsUpdating;
-        }
-
         /// <summary>
         /// Creates an instance of the work pump.
         /// </summary>
@@ -31,52 +17,14 @@ namespace Anvil.CSharp.DelayedExecution
         /// (optional) If true, the work scheduled while executing accumulated work will get executed during the same
         /// update.Otherwise, the work is deferred to the next update.
         /// </param>
-        public DeferredWorkPump(bool willEagerExecuteWork = false)
+        public DeferredWorkPump(bool willEagerExecuteWork = false) : base(ExecutePendingWork, willEagerExecuteWork) {}
+
+        private static void ExecutePendingWork(IEnumerator<Action> pendingWork)
         {
-            m_ExecutePendingWorkStrategy = willEagerExecuteWork ? (Action)ExecutePendingWork_Eager : ExecutePendingWork;
-
-            m_Update = UpdateHandle.Create<T>();
-            m_PendingWork = new Queue<Action>();
-        }
-
-        protected override void DisposeSelf()
-        {
-            m_Update.Dispose();
-
-            base.DisposeSelf();
-        }
-
-        /// <summary>
-        /// Schedules work to be executed during the next update phase.
-        /// </summary>
-        /// <param name="work"></param>
-        public void ScheduleWork(Action work)
-        {
-            m_PendingWork.Enqueue(work);
-            m_PendingWorkRequestHandle ??= m_Update.CallAfterUpdates(0, m_ExecutePendingWorkStrategy);
-        }
-
-        private void ExecutePendingWork()
-        {
-            // Cache the count before iterating so any new work scheduled during the current import work is pushed
-            // off to the next update.
-            m_PendingWorkRequestHandle = null;
-            int count = m_PendingWork.Count;
-
-            for (int i = 0; i < count; i++)
+            while (pendingWork.MoveNext())
             {
-                m_PendingWork.Dequeue()();
+                pendingWork.Current();
             }
-        }
-
-        private void ExecutePendingWork_Eager()
-        {
-            while (m_PendingWork.Count > 0)
-            {
-                m_PendingWork.Dequeue()();
-            }
-
-            m_PendingWorkRequestHandle = null;
         }
     }
 }

--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -17,7 +17,7 @@ namespace Anvil.CSharp.DelayedExecution
         /// (optional) If true, the work scheduled while executing accumulated work will get executed during the same
         /// update.Otherwise, the work is deferred to the next update.
         /// </param>
-        public DeferredWorkPump(bool willEagerExecuteWork = false) : base(ExecutePendingWork, willEagerExecuteWork) {}
+        public DeferredWorkPump(bool willEagerExecuteWork = false) : base(ExecutePendingWork, willEagerExecuteWork) { }
 
         private static void ExecutePendingWork(IEnumerator<Action> pendingWork)
         {

--- a/DelayedExecution/DeferredWorkPump.cs
+++ b/DelayedExecution/DeferredWorkPump.cs
@@ -7,7 +7,7 @@ namespace Anvil.CSharp.DelayedExecution
     /// Facilitates accumulating and deferring work to be executed at a specific, periodic, moment dictated by an
     /// <see cref="AbstractUpdateSource"/>
     /// </summary>
-    /// <typeparam name="T">The update source to schedule work against.</typeparam>
+    /// <typeparam name="TUpdateSource">The update source to schedule work against.</typeparam>
     public class DeferredWorkPump<TUpdateSource> : DeferredDataPump<TUpdateSource, Action> where TUpdateSource : AbstractUpdateSource
     {
         /// <summary>


### PR DESCRIPTION
Made the defer logic in `DeferredWorkPump` more generic so that any data (including delegates) could be accumulated and processed on an interval.

### What is the current behaviour?
There is no convenient way to defer data to be processed at a specific interval.

### What is the new behaviour?
`DeferredDataPump` can accumulate arbitrary data and process it with the provided callback providing an enumerator to iterate over the accumulated data.

The logic was moved from `DeferredWorkPump` which now extends `DeferredDataPump` to handle the bulk of its logic.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - The `ScheduleWork` method was renamed to `Schedule`
 - [ ] No
