### PR TITLE
LinqExtension - ContainsDuplicate

### DIFF
--- a/LINQ/LINQExtension.cs
+++ b/LINQ/LINQExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 
 namespace Anvil.CSharp.Linq
@@ -15,26 +16,26 @@ namespace Anvil.CSharp.Linq
         /// (Ex: <see cref="System.Threading.Tasks.Task"/>)
         /// </summary>
         /// <remarks>
-        /// Take care where this is placed in a query. It is most effective in a section of 
+        /// Take care where this is placed in a query. It is most effective in a section of
         /// the iteration that is lazy evaluated and visited often.
-        /// `AsCancellable()` can be specified multiple times in a query. The only overhead is additional 
-        /// <see cref="CancellationToken.IsCancellationRequested"/> checks. In some situations this can help 
+        /// `AsCancellable()` can be specified multiple times in a query. The only overhead is additional
+        /// <see cref="CancellationToken.IsCancellationRequested"/> checks. In some situations this can help
         /// improve the responsiveness of a cancellation request.
         /// </remarks>
         /// <example>
-        /// This is a poor placement of AsCancellable. The `ToArray()` instruction causes the myCollection to 
-        /// be iterated completely before getting into the expensive `Count()` condition. The `Count()` condition 
+        /// This is a poor placement of AsCancellable. The `ToArray()` instruction causes the myCollection to
+        /// be iterated completely before getting into the expensive `Count()` condition. The `Count()` condition
         /// is where most of the time will be spent but will not respond to cancellation requests since the instructions up to `Count()` have already been evaluated.
         /// myCollection
         ///     .AsCancellable()
         ///     .ToArray()
         ///     .Count(someExpensiveCondition);
-        ///     
+        ///
         /// Ideally, remove `ToArray()` so that `AsCancellable()` is getting evaluated on each iteration.
         /// myCollection
         ///     .AsCancellable()
         ///     .Count(someExpensiveCondition);
-        ///     
+        ///
         /// Alternatively, `AsCancelled()` can be moved below the `ToArray()` so that it is evaluated on each iteration.
         /// myCollection
         ///     .ToArray()
@@ -45,7 +46,7 @@ namespace Anvil.CSharp.Linq
         /// <param name="source">A sequence of values to iterate.</param>
         /// <param name="token">The cancellation token to monitor.</param>
         /// <returns>
-        /// An <see cref="IEnumerable{T}"/> whose next iteration aborts after 
+        /// An <see cref="IEnumerable{T}"/> whose next iteration aborts after
         /// <see cref="CancellationToken.IsCancellationRequested"/> is set to <see langword="true"/>.
         /// </returns>
         public static IEnumerable<TSource> AsCancellable<TSource>(this IEnumerable<TSource> source, CancellationToken token)
@@ -74,6 +75,17 @@ namespace Anvil.CSharp.Linq
             {
                 action(item);
             }
+        }
+
+        /// <summary>
+        /// Checks whether a collection contains duplicate elements using the default equality check.
+        /// </summary>
+        /// <param name="source">The collection to check.</param>
+        /// <typeparam name="TSource">The element type in the collection.</typeparam>
+        /// <returns>true if there are duplicate entries in the collection.</returns>
+        public static bool ContainsDuplicates<TSource>(this IEnumerable<TSource> source)
+        {
+            return source.Distinct().Count() != source.Count();
         }
     }
 }


### PR DESCRIPTION
Add a method to `LinqExtension` to check for duplicate elements in a colleciton.

There is probably a more efficient way to do this check but we can iterate on that in the future if needed.

### What is the current behaviour?

Linq doesn't include a convenient method to check whether there are duplicate elements in a collection.

### What is the new behaviour?

Developers can call `myCollection.ContainsDuplicates()` to determine whether there are duplicate elements in the collection.

### What issues does this resolve?

- none

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
