### PR TITLE
UpdateHandle - Fix error on call after completion

### DIFF
--- a/DelayedExecution/UpdateHandle.cs
+++ b/DelayedExecution/UpdateHandle.cs
@@ -144,6 +144,20 @@ namespace Anvil.CSharp.DelayedExecution
                 m_UpdateIterator.AddRange(m_CallAfterHandles.Values);
                 foreach (CallAfterHandle callAfterHandle in m_UpdateIterator)
                 {
+                    //TODO: #148 - Move to a two phase Update then Dispatch pass to avoid branching in the loops.
+                    // If the previous call handle updating caused the UpdateHandle to be disposed then stop updating
+                    // call handles. They'll all be disposed.
+                    if (IsDisposed)
+                    {
+                        break;
+                    }
+
+                    // If one of the previous call handles caused this call handle to be disposed then skip it.
+                    if (callAfterHandle.IsDisposed)
+                    {
+                        continue;
+                    }
+
                     callAfterHandle.Update();
                 }
                 m_UpdateIterator.Clear();


### PR DESCRIPTION
### What is the current behaviour?

If a CallAfterHandle's completion disposed another CallAfterHandle or the UpdateHandle itself within the stack the iteration would error/fail.


### What is the new behaviour?

IsDisposed is now checked on each iteration. Improvements to the fix are described in #148

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
