### PR TITLE
Content Group - Fix Exception on `Clear()` and Leak

### DIFF
--- a/Content/AbstractContentGroup.cs
+++ b/Content/AbstractContentGroup.cs
@@ -88,6 +88,7 @@ namespace Anvil.CSharp.Content
         public void Show(AbstractContentController contentController)
         {
             //TODO: Validate the passed in controller to ensure we avoid weird cases - https://github.com/scratch-games/anvil-unity-core/issues/3
+            m_PendingContentController?.Dispose();
 
             m_PendingContentController = contentController;
 

--- a/Content/AbstractContentGroup.cs
+++ b/Content/AbstractContentGroup.cs
@@ -89,10 +89,7 @@ namespace Anvil.CSharp.Content
         {
             //TODO: Validate the passed in controller to ensure we avoid weird cases - https://github.com/scratch-games/anvil-unity-core/issues/3
 
-            RemoveLifeCycleListeners(m_PendingContentController);
             m_PendingContentController = contentController;
-            m_PendingContentController.ContentGroup = this;
-            AttachLifeCycleListeners(m_PendingContentController);
 
             //If there's an Active Controller currently being shown, we need to clear it.
             if (ActiveContentController != null)
@@ -128,6 +125,9 @@ namespace Anvil.CSharp.Content
 
             ActiveContentController = m_PendingContentController;
             m_PendingContentController = null;
+
+            ActiveContentController.ContentGroup = this;
+            AttachLifeCycleListeners(ActiveContentController);
 
             ActiveContentController.InternalLoad();
         }
@@ -202,11 +202,6 @@ namespace Anvil.CSharp.Content
 
         private void AttachLifeCycleListeners(AbstractContentController contentController)
         {
-            if (contentController == null)
-            {
-                return;
-            }
-
             contentController.OnLoadStart += ContentController_OnLoadStart;
             contentController.OnLoadComplete += ContentController_OnLoadComplete;
             contentController.OnPlayInStart += ContentController_OnPlayInStart;
@@ -217,11 +212,6 @@ namespace Anvil.CSharp.Content
 
         private void RemoveLifeCycleListeners(AbstractContentController contentController)
         {
-            if (contentController == null)
-            {
-                return;
-            }
-
             contentController.OnLoadStart -= ContentController_OnLoadStart;
             contentController.OnLoadComplete -= ContentController_OnLoadComplete;
             contentController.OnPlayInStart -= ContentController_OnPlayInStart;


### PR DESCRIPTION
Fix an exception thrown on `AbstractContentGroup.Clear()` and a potential memory leak when changing views.

### What is the current behaviour?

When calling AbstractContentGroup.Clear() the group would throw an exception.
This is because `Show(null)` (aka `Clear()`) would try to set the pending content controller's `ContentGroup` to null.

When a pending content instance is overwritten before showing `Dispose()` is not called on the instance.

### What is the new behaviour?

All lifecycle listeners and group setting is now done in `ShowPendingContentController()` when the pending controller becomes the active controller.

`Show()` now calls `Dispose` on the pending content controller

### What issues does this resolve?
 - none

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
