### PR TITLE
EnumerableExtension - Add ToElementString

### DIFF
--- a/Collections/EnumerableExtension.cs
+++ b/Collections/EnumerableExtension.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Anvil.CSharp.Collections
+{
+    /// <summary>
+    /// A collection of extensions for working with <see cref="IEnumerable{T}"/>
+    /// </summary>
+    public static class EnumerableExtension
+    {
+        /// <summary>
+        /// Convert a collection of elements to a string representation calling <see cref="object.ToString()"/> on each one.
+        /// SampleOutput: "[element1,element2,element3]"
+        /// </summary>
+        /// <param name="collection">The collection of elements.</param>
+        /// <typeparam name="TElement">The type of element.</typeparam>
+        /// <returns>A string representation of the collection.</returns>
+        public static string ToElementString<TElement>(this IEnumerable<TElement> collection)
+        {
+            return $"[{string.Join(",", collection)}]";
+        }
+    }
+}


### PR DESCRIPTION
Create a convenience method for generating strings out of `IEnumerable<T>` instances.

### What is the current behaviour?

Functionality doesn't currently exist.

### What is the new behaviour?

`ToElementString` - Creates a string representation of an `IEnumerable<T>` instance calling `object.ToString()` on each element.

Results in a string like "[element1,element2,element3]"

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
