### PR TITLE
AbstractContentController - Add ContentManager getter

### DIFF
--- a/Content/AbstractContentController.cs
+++ b/Content/AbstractContentController.cs
@@ -74,6 +74,15 @@ namespace Anvil.CSharp.Content
         public AbstractContentGroup ContentGroup { get; internal set; }
 
         /// <summary>
+        /// Gets the <see cref="AbstractContentManager"/> that is at the root of the control for this content and the
+        /// group it resides in.
+        /// </summary>
+        public AbstractContentManager ContentManager
+        {
+            get => ContentGroup.ContentManager;
+        }
+
+        /// <summary>
         /// The ID for the <see cref="AbstractContentGroup"/> that this Controller should be shown on.
         /// </summary>
         public readonly string ContentGroupID;


### PR DESCRIPTION
Purely a convenience getter so you don't have to go through `ContentGroup`

### What is the current behaviour?

Developers have to get their content's manager through the group property.

### What is the new behaviour?

Developers have direct access to the `ContentManager` that their content is controlled by.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
