### PR TITLE
MathUtil - Add ClosestDelta + Tests

### DIFF
--- a/Mathematics/MathUtil.cs
+++ b/Mathematics/MathUtil.cs
@@ -45,5 +45,23 @@ namespace Anvil.CSharp.Mathematics
 
             return (--a);
         }
+
+        /// <summary>
+        /// Calculate the closest delta between two integers wrapping through the value's limits if required.
+        /// </summary>
+        /// <example>
+        /// ClosestDelta(int.MaxValue - 1, int.MinValue + 1) == 3;
+        /// </example>
+        /// /// <example>
+        /// ClosestDelta(int.MinValue + 1, int.MaxValue - 1) == -3;
+        /// </example>
+        public static int ClosestDelta(int val1, int val2)
+        {
+            uint uVal2 = unchecked((uint)val2);
+            uint uVal1 = unchecked((uint)val1);
+            uint uDelta = uVal2 - uVal1;
+
+            return unchecked((int)uDelta);
+        }
     }
 }

--- a/Tests/Mathematics/MathUtilTests.cs
+++ b/Tests/Mathematics/MathUtilTests.cs
@@ -19,5 +19,22 @@ namespace Anvil.CSharp.Tests
 
             Assert.That(MathUtil.FindPrimeNumber(100), Is.EqualTo(541));
         }
+
+        [Test]
+        public static void ClosestDeltaTest()
+        {
+            Assert.That(nameof(ClosestDeltaTest), Is.EqualTo(nameof(MathUtil.ClosestDelta) + "Test"));
+
+            //TODO: #129 - There's probably a more NUnit way to do this
+
+            Assert.That(MathUtil.ClosestDelta(5, 10), Is.EqualTo(5));
+            Assert.That(MathUtil.ClosestDelta(10, 5), Is.EqualTo(-5));
+
+            Assert.That(MathUtil.ClosestDelta(-5, -10), Is.EqualTo(-5));
+            Assert.That(MathUtil.ClosestDelta(-10, -5), Is.EqualTo(5));
+
+            Assert.That(MathUtil.ClosestDelta(int.MaxValue - 1, int.MinValue + 1), Is.EqualTo(3));
+            Assert.That(MathUtil.ClosestDelta(int.MinValue + 1, int.MaxValue - 1), Is.EqualTo(-3));
+        }
     }
 }


### PR DESCRIPTION
Calculate the closest delta between two values taking into account wrapping.

### What is the current behaviour?

This is new behaviour.

### What is the new behaviour?

`MathUtil.ClosestDelta` is provided.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
