### PR TITLE
Added `IndexOf` and `FindIndex` extensions for generic `IEnumerable<T>`

### DIFF
--- a/Collections/EnumerableExtension.cs
+++ b/Collections/EnumerableExtension.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Anvil.CSharp.Collections
 {
@@ -17,6 +19,42 @@ namespace Anvil.CSharp.Collections
         public static string ToElementString<TElement>(this IEnumerable<TElement> collection)
         {
             return $"[{string.Join(",", collection)}]";
+        }
+
+        /// <summary>
+        /// Find the first index in the enumerable matching the given predicate. Returns -1 if no matches are found.
+        /// </summary>
+        /// <param name="enumerable">The enumerable to search.</param>
+        /// <param name="predicate">The condition to match.</param>
+        /// <typeparam name="TElement">The type of the element.</typeparam>
+        /// <returns>The first index matching the given predicate, or -1 if none is found.</returns>
+        public static int FindIndex<TElement>(this IEnumerable<TElement> enumerable, Predicate<TElement> predicate)
+        {
+            return enumerable
+                .Select((element, i) => (element, i))
+                .Where(x => predicate(x.element))
+                .Select(x => x.i)
+                .DefaultIfEmpty(-1)
+                .First();
+        }
+
+        /// <summary>
+        /// Find the first index in the enumerable equal to the given object. Returns -1 if no matches are found.
+        /// </summary>
+        /// <param name="enumerable">The enumerable to search.</param>
+        /// <param name="element">The element to find.</param>
+        /// <typeparam name="TElement">The type of the element</typeparam>
+        /// <returns>The first index equal to the given object, or -1 if none is found.</returns>
+        public static int IndexOf<TElement>(this IEnumerable<TElement> enumerable, TElement element)
+        {
+            // NOTE: EqualityComparer<T>.Default is used instead of Object.Equals, because it checks for an
+            // IEquatable<T> override in cases where Object.Equals has not been overridden
+            return enumerable
+                .Select((el, i) => (el, i))
+                .Where(x => EqualityComparer<TElement>.Default.Equals(x.el, element))
+                .Select(x => x.i)
+                .DefaultIfEmpty(-1)
+                .First();
         }
     }
 }

--- a/Tests/Collections/EnumerableExtensionTests.cs
+++ b/Tests/Collections/EnumerableExtensionTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using Anvil.CSharp.Collections;
+using NUnit.Framework;
+
+namespace Anvil.CSharp.Tests
+{
+    public static class EnumerableExtensionTests
+    {
+        [Test]
+        public static void FindIndexTest()
+        {
+            Assert.That(nameof(FindIndexTest), Is.EqualTo(nameof(EnumerableExtension.FindIndex) + "Test"));
+
+            IEnumerable<int> numbers = Enumerable.Range(10, 50).ToArray();
+
+            Assert.That(numbers.FindIndex(x => x == 10), Is.EqualTo(0));
+            Assert.That(numbers.FindIndex(x => x == 42), Is.EqualTo(32));
+            Assert.That(numbers.FindIndex(x => x == -9999), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public static void IndexOfTest()
+        {
+            Assert.That(nameof(IndexOfTest), Is.EqualTo(nameof(EnumerableExtension.IndexOf) + "Test"));
+
+            IEnumerable<int> numbers = Enumerable.Range(10, 50).ToArray();
+
+            Assert.That(numbers.IndexOf(10), Is.EqualTo(0));
+            Assert.That(numbers.IndexOf(42), Is.EqualTo(32));
+            Assert.That(numbers.IndexOf(-9999), Is.EqualTo(-1));
+        }
+    }
+}


### PR DESCRIPTION
C#'s enumerable classes are fairly inconsistent, for example if you use `List<T>.AsReadOnly()` it returns a `ReadOnlyCollection<T>` which is technically unordered. If you instead implicitly cast your list to `IReadOnlyList<T>` it allows indexing, but no longer implements `IndexOf`. Adding these extension methods just lends greater flexibility to working with enumerables, without having to convert to `List<T>` or `Array` to access certain functionality.

### What is the current behaviour?

### What is the new behaviour?

### What issues does this resolve?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [X] No
