### PR TITLE
VersionControlUtil - Add FindRepositoryPath

### DIFF
--- a/IO/VersionControlUtil.cs
+++ b/IO/VersionControlUtil.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace Anvil.CSharp.IO
+{
+    /// <summary>
+    /// Useful utilities for interacting with version control.
+    /// </summary>
+    public static class VersionControlUtil
+    {
+        /// <summary>
+        /// Searches the provided path and parents for the root of the repository this project is located.
+        ///
+        /// </summary>
+        /// <param name="searchPath">The path to start the search from.</param>
+        /// <returns>
+        /// The full path to the root of the repository. If no repository is found then null is returned.
+        /// </returns>
+        public static string FindRepositoryPath(string searchPath)
+        {
+            DirectoryInfo currentPath = new DirectoryInfo(searchPath);
+            while (currentPath != null && !currentPath.EnumerateDirectories(".git").Any())
+            {
+                currentPath = currentPath.Parent;
+            }
+
+            return currentPath?.FullName;
+        }
+    }
+}


### PR DESCRIPTION
Searches the provided path and parents for the root of the repository this project is located.

### What is the current behaviour?

N/A

### What is the new behaviour?

A utility method that searches the provided path and parents for the root of the repository this project is located. Only supports git at the moment.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
