### PR TITLE
ListExtension - Add Shuffle

### DIFF
--- a/Collections/ListExtension.cs
+++ b/Collections/ListExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Anvil.CSharp.Collections
 {
@@ -21,6 +22,21 @@ namespace Anvil.CSharp.Collections
                 {
                     list.Add(item);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Shuffle the elements in a list using the Fisher-Yates algorithm.
+        /// </summary>
+        /// <param name="collection">The collection to shuffle the elements of</param>
+        /// <param name="randomProvider">Produces a random integer between arg1 (inclusive) and arg2 (exclusive)</param>
+        public static void Shuffle<T>(this IList<T> collection, Func<int, int, int> randomProvider)
+        {
+            int length = collection.Count;
+            for (int i = 0; i < length; i++)
+            {
+                int randomIndex =  randomProvider(0, length);
+                (collection[i], collection[randomIndex]) = (collection[randomIndex], collection[i]);
             }
         }
     }

--- a/Collections/ListExtension.cs
+++ b/Collections/ListExtension.cs
@@ -33,9 +33,9 @@ namespace Anvil.CSharp.Collections
         public static void Shuffle<T>(this IList<T> collection, Func<int, int, int> randomProvider)
         {
             int length = collection.Count;
-            for (int i = 0; i < length; i++)
+            for (int i = length-1; i > 0; i--)
             {
-                int randomIndex =  randomProvider(0, length);
+                int randomIndex =  randomProvider(0, i+1);
                 (collection[i], collection[randomIndex]) = (collection[randomIndex], collection[i]);
             }
         }


### PR DESCRIPTION
Shuffle elements of an IList using the Fisher-Yates algorithm

### What is the current behaviour?

 - None

### What is the new behaviour?

 - Implementations of `IList` can have their elements shuffled.

### What issues does this resolve?

 - None

### What PRs does this depend on?

 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
